### PR TITLE
feat: implement trait verification and property setter generation

### DIFF
--- a/crates/husk-dts-parser/src/codegen.rs
+++ b/crates/husk-dts-parser/src/codegen.rs
@@ -1157,9 +1157,25 @@ impl<'a> Codegen<'a> {
             writeln!(self.output).unwrap();
             writeln!(self.output, "impl {} {{", type_name).unwrap();
 
-            // Emit properties first with #[getter] syntax
+            // Emit properties with appropriate attributes
             for p in properties {
+                // Always add getter
                 writeln!(self.output, "    #[getter]").unwrap();
+
+                // Add setter for writable (non-readonly) properties
+                if !p.is_readonly {
+                    writeln!(self.output, "    #[setter]").unwrap();
+                }
+
+                // Static properties need special handling
+                if p.is_static {
+                    writeln!(
+                        self.output,
+                        "    // TODO: static property - may need manual adjustment"
+                    )
+                    .unwrap();
+                }
+
                 writeln!(self.output, "    extern \"js\" {}: {};", p.name, p.ty).unwrap();
             }
 

--- a/crates/husk-parser/src/lib.rs
+++ b/crates/husk-parser/src/lib.rs
@@ -2755,18 +2755,15 @@ mod tests {
                 assert_eq!(package, "nanoid");
                 assert_eq!(binding.name, "nanoid");
                 assert_eq!(items.len(), 1);
-                if let husk_ast::ModItemKind::Fn {
+                // ModItemKind has only Fn variant (MVP scope)
+                let husk_ast::ModItemKind::Fn {
                     name,
                     params,
                     ret_type,
-                } = &items[0].kind
-                {
-                    assert_eq!(name.name, "nanoid");
-                    assert!(params.is_empty());
-                    assert!(ret_type.is_some());
-                } else {
-                    panic!("expected Fn item in mod block");
-                }
+                } = &items[0].kind;
+                assert_eq!(name.name, "nanoid");
+                assert!(params.is_empty());
+                assert!(ret_type.is_some());
             } else {
                 panic!("expected Mod item");
             }


### PR DESCRIPTION
## Summary

This PR implements two missing features that were causing compiler warnings, plus fixes the `static` keyword that was missing from the lexer.

### Changes

**1. Trait Method Verification** (husk-semantic)
- Added `verify_trait_impls()` method that checks impl blocks provide all required trait methods
- Reports clear error messages: `impl of trait 'X' for 'Y' is missing method 'Z'`
- Added `span` field to `ImplInfo` for accurate error location reporting

**2. Property Getter/Setter Generation** (husk-dts-parser)
- Now generates `#[setter]` attribute for non-readonly properties from TypeScript
- Adds TODO comment for static properties (needs proper syntax design)
- The `is_readonly` and `is_static` fields are now used in code generation

**3. Compiler Warning Fixes**
- Added missing `static` keyword to lexer
- Replaced irrefutable `if let` patterns with direct `let` destructuring
- All single-variant enum patterns now use `let` for clarity

## Testing

- All 159 tests pass
- `cargo build` produces no warnings
- `cargo clippy` shows no dead code warnings

## Example Output

**Before (readonly property):**
```rust
#[getter]
extern "js" tagName: String;
```

**After (writable property):**
```rust
#[getter]
#[setter]
extern "js" textContent: String;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)