### PR TITLE
feat: add `js { ... }` syntax for embedding raw JavaScript

### DIFF
--- a/crates/husk-ast/src/lib.rs
+++ b/crates/husk-ast/src/lib.rs
@@ -193,6 +193,13 @@ pub enum ExprKind {
         op: AssignOp,
         value: Box<Expr>,
     },
+    /// Embedded JavaScript literal: `js { console.log("hi"); }`
+    /// The code field contains the raw JavaScript between the braces,
+    /// with leading/trailing whitespace trimmed but internal structure preserved.
+    JsLiteral {
+        /// The raw JavaScript code (content between braces, trimmed)
+        code: String,
+    },
 }
 
 // ============================================================================

--- a/crates/husk-codegen-js/src/lib.rs
+++ b/crates/husk-codegen-js/src/lib.rs
@@ -302,6 +302,8 @@ pub enum JsExpr {
         object: Box<JsExpr>,
         index: Box<JsExpr>,
     },
+    /// Raw JavaScript code, emitted directly (wrapped in parentheses for safety).
+    Raw(String),
 }
 
 /// Binary operators in JS (subset we need).
@@ -1391,6 +1393,10 @@ fn lower_expr(expr: &Expr, ctx: &CodegenContext) -> JsExpr {
                 right: Box::new(lower_expr(value, ctx)),
             }
         }
+        ExprKind::JsLiteral { code } => {
+            // Emit raw JavaScript code wrapped in parentheses for safe precedence
+            JsExpr::Raw(format!("({})", code))
+        }
     }
 }
 
@@ -2327,6 +2333,10 @@ fn write_expr(expr: &JsExpr, out: &mut String) {
             out.push('[');
             write_expr(index, out);
             out.push(']');
+        }
+        JsExpr::Raw(code) => {
+            // Emit raw JavaScript code directly (already wrapped in parentheses)
+            out.push_str(code);
         }
     }
 }

--- a/crates/husk-lexer/src/lib.rs
+++ b/crates/husk-lexer/src/lib.rs
@@ -6,7 +6,7 @@ use std::ops::Range;
 pub const KEYWORDS: &[&str] = &[
     "as", "pub", "use", "fn", "let", "mod", "mut", "struct", "enum", "type", "extern", "if",
     "else", "while", "match", "return", "true", "false", "break", "continue", "trait", "impl",
-    "for", "Self", "static", "in", "global",
+    "for", "Self", "static", "in", "global", "js",
 ];
 
 /// Check if a string is a Husk reserved keyword.
@@ -79,6 +79,7 @@ pub enum Keyword {
     SelfType, // `Self` keyword (capital S)
     Static,
     Global,
+    Js, // `js` keyword for embedded JavaScript blocks
 }
 
 /// Token kinds produced by the lexer.
@@ -265,6 +266,7 @@ impl<'src> Lexer<'src> {
             "Self" => TokenKind::Keyword(Keyword::SelfType),
             "static" => TokenKind::Keyword(Keyword::Static),
             "global" => TokenKind::Keyword(Keyword::Global),
+            "js" => TokenKind::Keyword(Keyword::Js),
             _ => TokenKind::Ident(text.to_string()),
         };
         Token { kind, span }

--- a/crates/husk-semantic/src/lib.rs
+++ b/crates/husk-semantic/src/lib.rs
@@ -1938,6 +1938,14 @@ impl<'a> FnContext<'a> {
                 // Assignment expression returns the assigned value
                 value_ty
             }
+            ExprKind::JsLiteral { .. } => {
+                // Raw JavaScript literals are treated as dynamically typed (JsValue)
+                // They can evaluate to any JavaScript value at runtime.
+                Type::Named {
+                    name: "JsValue".to_string(),
+                    args: Vec::new(),
+                }
+            }
         }
     }
 

--- a/examples/js_literal.hk
+++ b/examples/js_literal.hk
@@ -1,0 +1,60 @@
+// Example: Embedded JavaScript literals using `js { ... }` syntax
+//
+// This demonstrates embedding raw JavaScript code in Husk programs.
+
+fn main() {
+    // Simple expression - access Math.PI directly
+    let pi = js { Math.PI };
+    println("Pi: {}", pi);
+
+    // Object literal with nested braces
+    let obj = js { { name: "test", value: 42 } };
+    println("Object name: {}", js { obj.name });
+
+    // Function expression as callback
+    let double = js { function(x) { return x * 2; } };
+    let result = js { double(21) };
+    println("Double of 21: {}", result);
+
+    // Multi-line IIFE (Immediately Invoked Function Expression)
+    let computed = js {
+        (function() {
+            const items = [1, 2, 3, 4, 5];
+            return items.reduce((a, b) => a + b, 0);
+        })()
+    };
+    println("Sum of 1-5: {}", computed);
+
+    // Braces in strings are handled correctly
+    let json_str = js { JSON.stringify({ key: "value with } brace" }) };
+    println("JSON: {}", json_str);
+
+    // Comments with braces are handled correctly
+    let with_comment = js {
+        // This comment has a } brace
+        /* And this block comment has { braces } too */
+        42
+    };
+    println("With comment: {}", with_comment);
+
+    // Template literals are handled correctly
+    let greeting = js { `Hello, ${"World"}!` };
+    println("Greeting: {}", greeting);
+
+    // Arrow functions
+    let arr = js { [1, 2, 3, 4, 5] };
+    let mapped = js { arr.map(x => x * x) };
+    println("Squares: {}", js { mapped.join(", ") });
+
+    // Use js block with IIFE for multi-statement code
+    // (JsValue types aren't directly usable in Husk if conditions)
+    js {
+        (function() {
+            if (typeof window !== "undefined") {
+                console.log("Running in browser");
+            } else {
+                console.log("Running in Node.js");
+            }
+        })()
+    };
+}


### PR DESCRIPTION
## Summary
- Adds `js { ... }` syntax for embedding raw JavaScript code in Husk programs
- Parser uses a state machine to correctly track brace depth while handling strings, template literals, and comments
- JavaScript code is wrapped in parentheses for safe expression context in codegen

## Changes
- **Lexer**: Added `js` keyword
- **AST**: Added `JsLiteral { code: String }` variant to `ExprKind`
- **Parser**: Implemented `parse_js_literal()` with `JsParseState` enum for tracking context
- **Semantic**: Returns `JsValue` type for js literals
- **Codegen**: Added `JsExpr::Raw` variant

## Example Usage
```husk
// Simple expressions
let pi = js { Math.PI };

// Object literals with nested braces
let obj = js { { name: "test", value: 42 } };

// Multi-line IIFEs
let sum = js {
    (function() {
        const items = [1, 2, 3, 4, 5];
        return items.reduce((a, b) => a + b, 0);
    })()
};

// Handles strings/comments with braces correctly
let json = js { JSON.stringify({ key: "value with } brace" }) };
```

## Test plan
- [x] Compile and run `examples/js_literal.hk` - all test cases pass
- [x] Verify nested braces, strings, template literals, and comments are handled correctly