### PR TITLE
feat: add Rust-style variable shadowing support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,6 +460,7 @@ version = "0.1.0"
 dependencies = [
  "husk-ast",
  "husk-runtime-js",
+ "husk-semantic",
  "sourcemap",
 ]
 

--- a/crates/husk-cli/tests/node_examples.rs
+++ b/crates/husk-cli/tests/node_examples.rs
@@ -82,7 +82,7 @@ fn examples_execute_with_node_when_available() {
         );
 
         // Lower to JS with preamble (bin mode: auto-call main when present).
-        let module = lower_file_to_js(&file, true, JsTarget::Cjs);
+        let module = lower_file_to_js(&file, true, JsTarget::Cjs, &sem.name_resolution);
         let mut js = module.to_source_with_preamble();
 
         // For the minimal Express interop example, prepend a tiny stub `express`

--- a/crates/husk-cli/tests/ts_interop.rs
+++ b/crates/husk-cli/tests/ts_interop.rs
@@ -53,7 +53,7 @@ fn typescript_can_typecheck_generated_dts_when_available() {
     fs::create_dir_all(&out_dir).expect("failed to create ts-interop directory");
 
     // Emit JS + preamble and .d.ts side by side.
-    let module = lower_file_to_js(&file, false, JsTarget::Esm);
+    let module = lower_file_to_js(&file, false, JsTarget::Esm, &sem.name_resolution);
     let js = module.to_source_with_preamble();
     let js_path = out_dir.join("hello.js");
     fs::write(&js_path, js)

--- a/crates/husk-codegen-js/Cargo.toml
+++ b/crates/husk-codegen-js/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2024"
 [dependencies]
 husk-ast = { path = "../husk-ast" }
 husk-runtime-js = { path = "../husk-runtime-js" }
+husk-semantic = { path = "../husk-semantic" }
 sourcemap = "9"

--- a/crates/husk-codegen-js/src/lib.rs
+++ b/crates/husk-codegen-js/src/lib.rs
@@ -12,6 +12,7 @@ use husk_ast::{
     TypeExprKind,
 };
 use husk_runtime_js::std_preamble_js;
+use husk_semantic::NameResolution;
 use sourcemap::SourceMapBuilder;
 use std::collections::HashMap;
 use std::path::Path;
@@ -58,27 +59,46 @@ struct PropertyAccessors {
 /// This struct is threaded through all lowering functions to provide:
 /// - Property accessors for extern type method rewrites
 /// - Source file path for compile-time operations like include_str
+/// - Name resolution for variable shadowing
 #[derive(Debug, Clone)]
 struct CodegenContext<'a> {
     /// Property accessors for extern types
     accessors: &'a PropertyAccessors,
     /// Path to the current source file being compiled (for include_str, etc.)
     source_path: Option<&'a Path>,
+    /// Name resolution map from semantic analysis for variable shadowing.
+    /// Maps (span_start, span_end) -> resolved_name (e.g., "x", "x$1", "x$2")
+    name_resolution: &'a NameResolution,
 }
 
 impl<'a> CodegenContext<'a> {
-    fn new(accessors: &'a PropertyAccessors) -> Self {
+    fn new(accessors: &'a PropertyAccessors, name_resolution: &'a NameResolution) -> Self {
         Self {
             accessors,
             source_path: None,
+            name_resolution,
         }
     }
 
-    fn with_source_path(accessors: &'a PropertyAccessors, source_path: &'a Path) -> Self {
+    fn with_source_path(
+        accessors: &'a PropertyAccessors,
+        source_path: &'a Path,
+        name_resolution: &'a NameResolution,
+    ) -> Self {
         Self {
             accessors,
             source_path: Some(source_path),
+            name_resolution,
         }
+    }
+
+    /// Get the resolved name for a variable at the given span.
+    /// Returns the original name if not found in resolution map.
+    fn resolve_name(&self, name: &str, span: &Span) -> String {
+        self.name_resolution
+            .get(&(span.range.start, span.range.end))
+            .cloned()
+            .unwrap_or_else(|| name.to_string())
     }
 }
 
@@ -338,8 +358,16 @@ pub enum JsTarget {
 /// automatically invoked at the end of the module. Library-style
 /// consumers should set this to `false` so `main` can be called
 /// explicitly by a host.
-pub fn lower_file_to_js(file: &File, call_main: bool, target: JsTarget) -> JsModule {
-    lower_file_to_js_with_source(file, call_main, target, None, None)
+///
+/// `name_resolution` provides the mapping from variable spans to resolved names
+/// for handling variable shadowing. Use an empty HashMap if shadowing is not needed.
+pub fn lower_file_to_js(
+    file: &File,
+    call_main: bool,
+    target: JsTarget,
+    name_resolution: &NameResolution,
+) -> JsModule {
+    lower_file_to_js_with_source(file, call_main, target, None, None, name_resolution)
 }
 
 /// Lower a Husk AST file into a JS module with source text for accurate source maps.
@@ -347,12 +375,15 @@ pub fn lower_file_to_js(file: &File, call_main: bool, target: JsTarget) -> JsMod
 /// When `source` is provided, source spans will have accurate line/column info.
 /// When `source_path` is provided, compile-time operations like `include_str` can resolve
 /// relative file paths.
+/// `name_resolution` provides the mapping from variable spans to resolved names
+/// for handling variable shadowing.
 pub fn lower_file_to_js_with_source(
     file: &File,
     call_main: bool,
     target: JsTarget,
     source: Option<&str>,
     source_path: Option<&Path>,
+    name_resolution: &NameResolution,
 ) -> JsModule {
     use std::collections::HashSet;
 
@@ -455,10 +486,10 @@ pub fn lower_file_to_js_with_source(
         }
     }
 
-    // Create codegen context with accessors and optional source path
+    // Create codegen context with accessors, optional source path, and name resolution
     let ctx = match source_path {
-        Some(path) => CodegenContext::with_source_path(&accessors, path),
-        None => CodegenContext::new(&accessors),
+        Some(path) => CodegenContext::with_source_path(&accessors, path, name_resolution),
+        None => CodegenContext::new(&accessors, name_resolution),
     };
 
     // First pass: collect module imports
@@ -931,7 +962,7 @@ fn lower_stmt(stmt: &Stmt, ctx: &CodegenContext) -> JsStmt {
             ty: _,
             value,
         } => JsStmt::Let {
-            name: name.name.clone(),
+            name: ctx.resolve_name(&name.name, &name.span),
             init: value.as_ref().map(|e| lower_expr(e, ctx)),
         },
         StmtKind::Expr(expr) | StmtKind::Semi(expr) => JsStmt::Expr(lower_expr(expr, ctx)),
@@ -1000,7 +1031,7 @@ fn lower_stmt(stmt: &Stmt, ctx: &CodegenContext) -> JsStmt {
                 let js_body: Vec<JsStmt> = body.stmts.iter().map(|s| lower_stmt(s, ctx)).collect();
 
                 JsStmt::For {
-                    binding: binding.name.clone(),
+                    binding: ctx.resolve_name(&binding.name, &binding.span),
                     start: js_start,
                     end: js_end,
                     inclusive: *inclusive,
@@ -1010,7 +1041,7 @@ fn lower_stmt(stmt: &Stmt, ctx: &CodegenContext) -> JsStmt {
                 let js_iterable = lower_expr(iterable, ctx);
                 let js_body: Vec<JsStmt> = body.stmts.iter().map(|s| lower_stmt(s, ctx)).collect();
                 JsStmt::ForOf {
-                    binding: binding.name.clone(),
+                    binding: ctx.resolve_name(&binding.name, &binding.span),
                     iterable: js_iterable,
                     body: js_body,
                 }
@@ -1072,7 +1103,8 @@ fn lower_expr(expr: &Expr, ctx: &CodegenContext) -> JsExpr {
             if id.name == "self" {
                 JsExpr::Ident("this".to_string())
             } else {
-                JsExpr::Ident(id.name.clone())
+                // Use resolved name from name_resolution if available
+                JsExpr::Ident(ctx.resolve_name(&id.name, &id.span))
             }
         }
         ExprKind::Path { segments } => {
@@ -1287,7 +1319,10 @@ fn lower_expr(expr: &Expr, ctx: &CodegenContext) -> JsExpr {
             // Lower closure to JS arrow function.
             // `|x, y| x + y` -> `(x, y) => x + y`
             // `|x: i32| -> i32 { x + 1 }` -> `(x) => { return x + 1; }`
-            let js_params: Vec<String> = params.iter().map(|p| p.name.name.clone()).collect();
+            let js_params: Vec<String> = params
+                .iter()
+                .map(|p| ctx.resolve_name(&p.name.name, &p.name.span))
+                .collect();
 
             // Check if the body is a block or a simple expression
             let js_body = match &body.kind {
@@ -2595,7 +2630,8 @@ mod tests {
             items: vec![main_fn, helper_fn],
         };
 
-        let module = lower_file_to_js(&file, true, JsTarget::Cjs);
+        let empty_resolution = HashMap::new();
+        let module = lower_file_to_js(&file, true, JsTarget::Cjs, &empty_resolution);
         let src = module.to_source();
 
         assert!(src.contains("function main()"));
@@ -2692,7 +2728,8 @@ mod tests {
             span: span(0, 60),
         };
 
-        let js = lower_expr(&match_expr, &CodegenContext::new(&PropertyAccessors::default()));
+        let empty_resolution = HashMap::new();
+        let js = lower_expr(&match_expr, &CodegenContext::new(&PropertyAccessors::default(), &empty_resolution));
         let mut out = String::new();
         write_expr(&js, &mut out);
 
@@ -2732,7 +2769,8 @@ mod tests {
             items: vec![fn_item],
         };
 
-        let module = lower_file_to_js(&file, true, JsTarget::Cjs);
+        let empty_resolution = HashMap::new();
+        let module = lower_file_to_js(&file, true, JsTarget::Cjs, &empty_resolution);
         let src = module.to_source();
 
         assert!(src.contains("function main()"));
@@ -2929,7 +2967,8 @@ mod tests {
             }],
         };
 
-        let module = lower_file_to_js(&file, true, JsTarget::Cjs);
+        let empty_resolution = HashMap::new();
+        let module = lower_file_to_js(&file, true, JsTarget::Cjs, &empty_resolution);
         let src = module.to_source();
 
         assert!(src.contains("function parse"));
@@ -2959,6 +2998,7 @@ mod tests {
                 package: "express".to_string(),
                 binding: ident("express", 0),
                 items: Vec::new(),
+                is_global: false,
             },
             span: span(0, 10),
         };
@@ -2968,6 +3008,7 @@ mod tests {
                 package: "fs".to_string(),
                 binding: ident("fs", 20),
                 items: Vec::new(),
+                is_global: false,
             },
             span: span(20, 25),
         };
@@ -3000,7 +3041,8 @@ mod tests {
             ],
         };
 
-        let module = lower_file_to_js(&file, true, JsTarget::Esm);
+        let empty_resolution = HashMap::new();
+        let module = lower_file_to_js(&file, true, JsTarget::Esm, &empty_resolution);
         let src = module.to_source();
 
         // Check for ESM imports at the top
@@ -3036,7 +3078,8 @@ mod tests {
         let file = husk_ast::File {
             items: vec![main_fn],
         };
-        let module = lower_file_to_js(&file, true, JsTarget::Esm);
+        let empty_resolution = HashMap::new();
+        let module = lower_file_to_js(&file, true, JsTarget::Esm, &empty_resolution);
         let src = module.to_source();
 
         assert!(src.contains("export { main }"));
@@ -3058,6 +3101,7 @@ mod tests {
                 package: "express".to_string(),
                 binding: ident("express", 0),
                 items: Vec::new(),
+                is_global: false,
             },
             span: span(0, 10),
         };
@@ -3090,7 +3134,8 @@ mod tests {
             ],
         };
 
-        let module = lower_file_to_js(&file, true, JsTarget::Cjs);
+        let empty_resolution = HashMap::new();
+        let module = lower_file_to_js(&file, true, JsTarget::Cjs, &empty_resolution);
         let src = module.to_source();
 
         assert!(src.contains("const express = require(\"express\");"));
@@ -3132,7 +3177,8 @@ mod tests {
         };
 
         let accessors = PropertyAccessors::default();
-        let ctx = CodegenContext::new(&accessors);
+        let empty_resolution = HashMap::new();
+        let ctx = CodegenContext::new(&accessors, &empty_resolution);
         let js_expr = lower_expr(&format_expr, &ctx);
         let mut js_str = String::new();
         write_expr(&js_expr, &mut js_str);
@@ -3195,7 +3241,8 @@ mod tests {
         };
 
         let accessors = PropertyAccessors::default();
-        let ctx = CodegenContext::new(&accessors);
+        let empty_resolution = HashMap::new();
+        let ctx = CodegenContext::new(&accessors, &empty_resolution);
         let js_expr = lower_expr(&format_expr, &ctx);
         let mut js_str = String::new();
         write_expr(&js_expr, &mut js_str);
@@ -3230,7 +3277,8 @@ mod tests {
         };
 
         let accessors = PropertyAccessors::default();
-        let ctx = CodegenContext::new(&accessors);
+        let empty_resolution = HashMap::new();
+        let ctx = CodegenContext::new(&accessors, &empty_resolution);
         let js_expr = lower_expr(&format_expr, &ctx);
         let mut js_str = String::new();
         write_expr(&js_expr, &mut js_str);

--- a/crates/husk-parser/src/lib.rs
+++ b/crates/husk-parser/src/lib.rs
@@ -3099,6 +3099,7 @@ mod tests {
                 package,
                 binding,
                 items,
+                ..
             } = &items[0].kind
             {
                 assert_eq!(package, "express");
@@ -3123,6 +3124,7 @@ mod tests {
                 package,
                 binding,
                 items,
+                ..
             } = &items[0].kind
             {
                 assert_eq!(package, "lodash-es");
@@ -3147,6 +3149,7 @@ mod tests {
                 package,
                 binding,
                 items,
+                ..
             } = &items[0].kind
             {
                 assert_eq!(package, "@myorg/my-lib");
@@ -3176,6 +3179,7 @@ mod tests {
                 package,
                 binding,
                 items,
+                ..
             } = &items[0].kind
             {
                 assert_eq!(package, "nanoid");

--- a/crates/husk-semantic/src/lib.rs
+++ b/crates/husk-semantic/src/lib.rs
@@ -72,11 +72,23 @@ pub struct SemanticError {
     pub span: Span,
 }
 
+/// Maps variable binding and usage spans to their resolved unique names.
+///
+/// During code generation, variable references need unique names to handle
+/// shadowing correctly. JavaScript doesn't allow redeclaring `let` in the
+/// same scope, so we use alpha-conversion (renaming) to generate unique names.
+///
+/// The map uses byte ranges (start, end) as keys since `Span` doesn't implement Hash.
+/// Values are the resolved names (e.g., "x", "x$1", "x$2").
+pub type NameResolution = HashMap<(usize, usize), String>;
+
 /// The result of running semantic analysis (name resolution + type checking) on a Husk file.
 #[derive(Debug)]
 pub struct SemanticResult {
     pub symbols: ModuleSymbols,
     pub type_errors: Vec<SemanticError>,
+    /// Maps variable spans to their resolved unique names for codegen.
+    pub name_resolution: NameResolution,
 }
 
 /// Options controlling semantic analysis.
@@ -160,10 +172,11 @@ pub fn analyze_file_with_options(file: &File, opts: SemanticOptions) -> Semantic
         checker.build_type_env(js_globals_file());
     }
     checker.build_type_env(&filtered_file);
-    let type_errors = checker.check_file(&filtered_file);
+    let (type_errors, name_resolution) = checker.check_file(&filtered_file);
     SemanticResult {
         symbols,
         type_errors,
+        name_resolution,
     }
 }
 
@@ -341,6 +354,8 @@ fn type_expr_to_name(ty: &TypeExpr) -> String {
 struct TypeChecker {
     env: TypeEnv,
     errors: Vec<SemanticError>,
+    /// Maps variable spans to their resolved unique names for codegen.
+    name_resolution: NameResolution,
 }
 
 impl TypeChecker {
@@ -348,6 +363,7 @@ impl TypeChecker {
         Self {
             env: TypeEnv::default(),
             errors: Vec::new(),
+            name_resolution: HashMap::new(),
         }
     }
 
@@ -580,7 +596,7 @@ impl TypeChecker {
         }
     }
 
-    fn check_file(&mut self, file: &File) -> Vec<SemanticError> {
+    fn check_file(&mut self, file: &File) -> (Vec<SemanticError>, NameResolution) {
         // Verify trait implementations
         self.verify_trait_impls();
 
@@ -598,7 +614,7 @@ impl TypeChecker {
                 self.check_fn(name, type_params, params, ret_type.as_ref(), body, item.span.clone());
             }
         }
-        self.errors.clone()
+        (self.errors.clone(), std::mem::take(&mut self.name_resolution))
     }
 
     fn check_fn(
@@ -623,6 +639,8 @@ impl TypeChecker {
         };
 
         let mut locals: HashMap<String, Type> = HashMap::new();
+        let mut shadow_counts: HashMap<String, u32> = HashMap::new();
+        let mut resolved_names: HashMap<String, String> = HashMap::new();
 
         // Parameters must have explicit types.
         for param in params {
@@ -636,11 +654,21 @@ impl TypeChecker {
                     span: param.name.span.clone(),
                 });
             }
+            // Register parameter in name resolution (no shadowing for params)
+            let resolved = param.name.name.clone();
+            shadow_counts.insert(param.name.name.clone(), 0);
+            resolved_names.insert(param.name.name.clone(), resolved.clone());
+            self.name_resolution.insert(
+                (param.name.span.range.start, param.name.span.range.end),
+                resolved,
+            );
         }
 
         let mut ctx = FnContext {
             tcx: self,
             locals,
+            shadow_counts,
+            resolved_names,
             ret_ty,
             in_loop: false,
         };
@@ -773,11 +801,46 @@ impl TypeChecker {
 struct FnContext<'a> {
     tcx: &'a mut TypeChecker,
     locals: HashMap<String, Type>,
+    /// Maps variable names to their current shadow count.
+    /// When a variable is shadowed, we increment its count.
+    shadow_counts: HashMap<String, u32>,
+    /// Maps variable names to their current resolved name (e.g., "x" -> "x$1").
+    /// Used to resolve variable references to the correct shadowed version.
+    resolved_names: HashMap<String, String>,
     ret_ty: Type,
     in_loop: bool,
 }
 
 impl<'a> FnContext<'a> {
+    /// Bind a variable with shadowing support.
+    ///
+    /// Returns the resolved name (e.g., "x", "x$1", "x$2") and registers it
+    /// in the name resolution map.
+    fn bind_variable(&mut self, name: &str, ty: Type, span: &Span) -> String {
+        // Get or initialize the shadow count for this variable name
+        let count = self.shadow_counts.entry(name.to_string()).or_insert(0);
+        let resolved = if *count == 0 {
+            name.to_string()
+        } else {
+            format!("{}${}", name, count)
+        };
+        *count += 1;
+
+        // Update the current resolved name for this variable
+        self.resolved_names.insert(name.to_string(), resolved.clone());
+
+        // Add to locals for type checking
+        self.locals.insert(name.to_string(), ty);
+
+        // Register in name resolution map
+        self.tcx.name_resolution.insert(
+            (span.range.start, span.range.end),
+            resolved.clone(),
+        );
+
+        resolved
+    }
+
     fn check_path_expr(&mut self, expr: &Expr, segments: &[Ident]) -> Type {
         // MVP: treat `Enum::Variant` as a constructor function.
         if segments.len() >= 2 {
@@ -878,9 +941,14 @@ impl<'a> FnContext<'a> {
 
             // Type-check the arm expression in a fresh scope with any bindings from the pattern.
             let saved_locals = self.locals.clone();
-            self.bind_pattern_locals(&arm.pattern, &scrut_ty);
+            let saved_shadow_counts = self.shadow_counts.clone();
+            let saved_resolved_names = self.resolved_names.clone();
+            let mut pattern_bindings = HashSet::new();
+            self.bind_pattern_locals(&arm.pattern, &scrut_ty, &mut pattern_bindings);
             let arm_ty = self.check_expr(&arm.expr);
             self.locals = saved_locals;
+            self.shadow_counts = saved_shadow_counts;
+            self.resolved_names = saved_resolved_names;
 
             match &mut result_ty {
                 None => result_ty = Some(arm_ty),
@@ -918,20 +986,32 @@ impl<'a> FnContext<'a> {
         result_ty.unwrap_or(Type::Primitive(PrimitiveType::Unit))
     }
 
-    fn bind_pattern_locals(&mut self, pat: &Pattern, scrut_ty: &Type) {
+    /// Bind pattern locals with shadowing support.
+    ///
+    /// The `pattern_bindings` set tracks bindings within the current pattern
+    /// to detect duplicate bindings like `(x, x)` which should still be an error.
+    /// Shadowing outer variables is allowed.
+    fn bind_pattern_locals(
+        &mut self,
+        pat: &Pattern,
+        scrut_ty: &Type,
+        pattern_bindings: &mut HashSet<String>,
+    ) {
         match &pat.kind {
             PatternKind::Wildcard => {}
             PatternKind::Binding(id) => {
-                if self
-                    .locals
-                    .insert(id.name.clone(), scrut_ty.clone())
-                    .is_some()
-                {
+                // Check for duplicate binding within the same pattern (e.g., `(x, x)`)
+                if !pattern_bindings.insert(id.name.clone()) {
                     self.tcx.errors.push(SemanticError {
-                        message: format!("duplicate binding `{}` in pattern", id.name),
+                        message: format!(
+                            "identifier `{}` is bound more than once in the same pattern",
+                            id.name
+                        ),
                         span: id.span.clone(),
                     });
                 }
+                // Allow shadowing outer variables
+                self.bind_variable(&id.name, scrut_ty.clone(), &id.span);
             }
             PatternKind::EnumUnit { .. } => {}
             PatternKind::EnumTuple { .. } | PatternKind::EnumStruct { .. } => {
@@ -979,12 +1059,8 @@ impl<'a> FnContext<'a> {
                     }
                 };
 
-                if self.locals.insert(name.name.clone(), final_ty).is_some() {
-                    self.tcx.errors.push(SemanticError {
-                        message: format!("duplicate local binding `{}`", name.name),
-                        span: name.span.clone(),
-                    });
-                }
+                // Bind the variable with shadowing support
+                self.bind_variable(&name.name, final_ty, &name.span);
             }
             StmtKind::Assign { target, op, value } => {
                 // Validate target is assignable (lvalue: ident, field, or index)
@@ -1119,8 +1195,13 @@ impl<'a> FnContext<'a> {
                     }
                 };
 
-                // Bind loop variable in scope
-                let old_binding = self.locals.insert(binding.name.clone(), elem_ty);
+                // Save current scope state
+                let old_locals = self.locals.clone();
+                let old_shadow_counts = self.shadow_counts.clone();
+                let old_resolved_names = self.resolved_names.clone();
+
+                // Bind loop variable with shadowing support
+                self.bind_variable(&binding.name, elem_ty, &binding.span);
 
                 // Check body in loop context
                 let prev_in_loop = self.in_loop;
@@ -1128,12 +1209,10 @@ impl<'a> FnContext<'a> {
                 self.check_block(body);
                 self.in_loop = prev_in_loop;
 
-                // Restore previous binding if any
-                if let Some(old_ty) = old_binding {
-                    self.locals.insert(binding.name.clone(), old_ty);
-                } else {
-                    self.locals.remove(&binding.name);
-                }
+                // Restore scope state
+                self.locals = old_locals;
+                self.shadow_counts = old_shadow_counts;
+                self.resolved_names = old_resolved_names;
             }
             StmtKind::Break | StmtKind::Continue => {
                 if !self.in_loop {
@@ -1156,10 +1235,14 @@ impl<'a> FnContext<'a> {
 
     fn check_block(&mut self, block: &Block) {
         let old_locals = self.locals.clone();
+        let old_shadow_counts = self.shadow_counts.clone();
+        let old_resolved_names = self.resolved_names.clone();
         for stmt in &block.stmts {
             self.check_stmt(stmt);
         }
         self.locals = old_locals;
+        self.shadow_counts = old_shadow_counts;
+        self.resolved_names = old_resolved_names;
     }
 
     fn check_expr(&mut self, expr: &Expr) -> Type {
@@ -1173,6 +1256,13 @@ impl<'a> FnContext<'a> {
             ExprKind::Path { segments } => self.check_path_expr(expr, segments),
             ExprKind::Ident(id) => {
                 if let Some(ty) = self.locals.get(&id.name) {
+                    // Register the resolved name for this variable usage
+                    if let Some(resolved) = self.resolved_names.get(&id.name) {
+                        self.tcx.name_resolution.insert(
+                            (id.span.range.start, id.span.range.end),
+                            resolved.clone(),
+                        );
+                    }
                     return ty.clone();
                 }
                 // Try top-level function.
@@ -1979,6 +2069,8 @@ impl<'a> FnContext<'a> {
         // Resolve parameter types
         let mut param_types = Vec::new();
         let mut closure_locals = self.locals.clone();
+        let mut closure_shadow_counts = self.shadow_counts.clone();
+        let mut closure_resolved_names = self.resolved_names.clone();
 
         for (i, param) in params.iter().enumerate() {
             let ty = if let Some(type_expr) = &param.ty {
@@ -2031,6 +2123,20 @@ impl<'a> FnContext<'a> {
 
             param_types.push(ty.clone());
             closure_locals.insert(param.name.name.clone(), ty);
+
+            // Register closure parameter in name resolution (may shadow outer variables)
+            let count = closure_shadow_counts.entry(param.name.name.clone()).or_insert(0);
+            let resolved = if *count == 0 {
+                param.name.name.clone()
+            } else {
+                format!("{}${}", param.name.name, count)
+            };
+            *count += 1;
+            closure_resolved_names.insert(param.name.name.clone(), resolved.clone());
+            self.tcx.name_resolution.insert(
+                (param.name.span.range.start, param.name.span.range.end),
+                resolved,
+            );
         }
 
         // Check arity mismatch (fewer params than expected)
@@ -2060,6 +2166,8 @@ impl<'a> FnContext<'a> {
 
         // Create a nested context for the closure body
         let old_locals = std::mem::replace(&mut self.locals, closure_locals);
+        let old_shadow_counts = std::mem::replace(&mut self.shadow_counts, closure_shadow_counts);
+        let old_resolved_names = std::mem::replace(&mut self.resolved_names, closure_resolved_names);
         let old_ret_ty = std::mem::replace(&mut self.ret_ty, expected_ret_ty.clone());
 
         // Check the body and infer return type
@@ -2067,6 +2175,8 @@ impl<'a> FnContext<'a> {
 
         // Restore the outer context
         self.locals = old_locals;
+        self.shadow_counts = old_shadow_counts;
+        self.resolved_names = old_resolved_names;
         self.ret_ty = old_ret_ty;
 
         // Use explicit return type if specified, otherwise infer from body
@@ -2875,6 +2985,7 @@ mod tests {
                 package: "express".to_string(),
                 binding: express_ident.clone(),
                 items: Vec::new(),
+                is_global: false,
             },
             span: Span { range: 0..15 },
         };

--- a/examples/shadowing.hk
+++ b/examples/shadowing.hk
@@ -1,0 +1,74 @@
+// Variable shadowing in Husk - demonstration of Rust-like shadowing semantics
+
+// Test same-scope shadowing with same type
+#[cfg(test)]
+#[test]
+fn test_same_type_shadowing() {
+    let x = 5;
+    let x = 10;  // Shadows the previous x
+    assert(x == 10);
+}
+
+// Test closure capturing correct shadowed variable
+#[cfg(test)]
+#[test]
+fn test_closure_capture() {
+    let x = 100;
+    let get_x = || x;  // Captures x = 100
+    let x = 200;       // Shadows x
+    assert(get_x() == 100);  // Should still return 100, not 200
+}
+
+// Test shadowing with closures as values
+#[cfg(test)]
+#[test]
+fn test_shadowed_closure() {
+    let f = |n: i32| n + 1;
+    let result = f(10);    // Should be 11
+    let f = |n: i32| n * 2;
+    assert(result + f(10) == 31);  // Should be 11 + 20 = 31
+}
+
+// Test shadowing in for loop - basic
+#[cfg(test)]
+#[test]
+fn test_loop_shadowing() {
+    let sum = 0;
+    for i in 0..3 {
+        let i = i + 10;  // Shadow loop variable
+    }
+    assert(sum == 0);  // Original sum is unchanged
+}
+
+// Test shadowing loop variable with transformed version (like `let name = name.trim()`)
+#[cfg(test)]
+#[test]
+fn test_loop_var_transform_shadow() {
+    let total = 0;
+    for n in 0..3 {
+        let n = n * 2;      // Shadow n with transformed value
+        let n = n + 1;      // Shadow again
+        // n values: 0->0->1, 1->2->3, 2->4->5
+    }
+    assert(total == 0);  // Outer variable unchanged
+}
+
+// Test multiple sequential shadows
+#[cfg(test)]
+#[test]
+fn test_multiple_shadows() {
+    let x = 1;
+    let x = x + 1;  // x = 2
+    let x = x * 3;  // x = 6
+    let x = x - 1;  // x = 5
+    assert(x == 5);
+}
+
+// Entry point for manual testing
+fn main() {
+    println("same_type_shadowing: 10");
+    println("closure_capture: 100");
+    println("shadowed_closure: 31");
+    println("loop_shadowing: 0");
+    println("multiple_shadows: 5");
+}


### PR DESCRIPTION
## Summary
- Implements Rust-style variable shadowing using alpha-conversion
- Shadowed variables are renamed to unique identifiers (x, x$1, x$2) in generated JavaScript
- Adds comprehensive test suite for shadowing scenarios

## Changes
- **Semantic analysis**: Added `NameResolution` type and `bind_variable()` helper with shadow counting per scope
- **Code generation**: Added span-based name resolution lookup, updated all codegen paths
- **CLI**: Filter AST by cfg flags before codegen to prevent invalid JS output
- **Tests**: New `examples/shadowing.hk` with tests for various shadowing contexts

## Test plan
- [x] `cargo test` passes
- [x] `huskc test examples/shadowing.hk` passes all 6 test cases
- [x] `huskc build examples/shadowing.hk` produces valid JavaScript
- [x] Existing examples still compile and run correctly