### PR TITLE
feat: add loop keyword for infinite loops

### DIFF
--- a/crates/husk-ast/src/lib.rs
+++ b/crates/husk-ast/src/lib.rs
@@ -353,6 +353,11 @@ pub enum StmtKind {
         cond: Expr,
         body: Block,
     },
+    /// Infinite loop: `loop { body }`
+    /// Can only be exited via `break` or `return`.
+    Loop {
+        body: Block,
+    },
     /// For-in loop: `for item in collection { body }`
     ForIn {
         binding: Ident,

--- a/crates/husk-fmt/src/lib.rs
+++ b/crates/husk-fmt/src/lib.rs
@@ -209,4 +209,44 @@ pub struct User {
         assert!(result.contains(r#""\\""#), "\\\\ not preserved. Got:\n{}", result);
         assert!(result.contains(r#""\"""#), "\\\" not preserved. Got:\n{}", result);
     }
+
+    #[test]
+    fn test_format_loop_statement() {
+        let source = r#"fn main() {
+    loop {
+        break;
+    }
+}"#;
+        let result = format_str(source, &FormatConfig::default()).unwrap();
+        assert!(result.contains("loop {"), "Expected 'loop {{' in output. Got:\n{}", result);
+        assert!(result.contains("break;"), "Expected 'break;' in output. Got:\n{}", result);
+    }
+
+    #[test]
+    fn test_format_loop_with_continue() {
+        let source = r#"fn main() {
+    loop {
+        continue;
+    }
+}"#;
+        let result = format_str(source, &FormatConfig::default()).unwrap();
+        assert!(result.contains("loop {"), "Expected 'loop {{' in output. Got:\n{}", result);
+        assert!(result.contains("continue;"), "Expected 'continue;' in output. Got:\n{}", result);
+    }
+
+    #[test]
+    fn test_format_loop_preserves_body() {
+        let source = r#"fn main() {
+    loop {
+        let x = 1;
+        if x > 0 {
+            break;
+        }
+    }
+}"#;
+        let result = format_str(source, &FormatConfig::default()).unwrap();
+        assert!(result.contains("loop {"), "Expected 'loop {{' in output. Got:\n{}", result);
+        assert!(result.contains("let x = 1;"), "Expected 'let x = 1;' in output. Got:\n{}", result);
+        assert!(result.contains("if x > 0"), "Expected 'if x > 0' in output. Got:\n{}", result);
+    }
 }

--- a/crates/husk-fmt/src/visitor.rs
+++ b/crates/husk-fmt/src/visitor.rs
@@ -941,6 +941,17 @@ impl<'a> Formatter<'a> {
                 self.write_indent();
                 self.write("}");
             }
+            StmtKind::Loop { body } => {
+                self.write_indent();
+                self.write("loop {");
+                self.newline();
+                self.indent += 1;
+                self.format_stmts(&body.stmts);
+                self.emit_block_end_trivia(body.span.range.end);
+                self.indent -= 1;
+                self.write_indent();
+                self.write("}");
+            }
             StmtKind::ForIn {
                 binding,
                 iterable,

--- a/crates/husk-lexer/src/lib.rs
+++ b/crates/husk-lexer/src/lib.rs
@@ -33,8 +33,8 @@ impl Trivia {
 /// List of all Husk keywords.
 pub const KEYWORDS: &[&str] = &[
     "as", "pub", "use", "fn", "let", "mod", "mut", "struct", "enum", "type", "extern", "if",
-    "else", "while", "match", "return", "true", "false", "break", "continue", "trait", "impl",
-    "for", "Self", "static", "in", "global", "js",
+    "else", "while", "loop", "match", "return", "true", "false", "break", "continue", "trait",
+    "impl", "for", "Self", "static", "in", "global", "js",
 ];
 
 /// Check if a string is a Husk reserved keyword.
@@ -94,6 +94,7 @@ pub enum Keyword {
     If,
     Else,
     While,
+    Loop,
     Match,
     Return,
     True,
@@ -414,6 +415,7 @@ impl<'src> Lexer<'src> {
             "if" => TokenKind::Keyword(Keyword::If),
             "else" => TokenKind::Keyword(Keyword::Else),
             "while" => TokenKind::Keyword(Keyword::While),
+            "loop" => TokenKind::Keyword(Keyword::Loop),
             "match" => TokenKind::Keyword(Keyword::Match),
             "break" => TokenKind::Keyword(Keyword::Break),
             "continue" => TokenKind::Keyword(Keyword::Continue),

--- a/crates/husk-parser/src/lib.rs
+++ b/crates/husk-parser/src/lib.rs
@@ -1563,6 +1563,7 @@ impl<'src> Parser<'src> {
             TokenKind::Keyword(Keyword::Return) => self.parse_return_stmt(),
             TokenKind::Keyword(Keyword::If) => self.parse_if_stmt(),
             TokenKind::Keyword(Keyword::While) => self.parse_while_stmt(),
+            TokenKind::Keyword(Keyword::Loop) => self.parse_loop_stmt(),
             TokenKind::Keyword(Keyword::For) => self.parse_for_in_stmt(),
             TokenKind::Keyword(Keyword::Break) => self.parse_break_stmt(),
             TokenKind::Keyword(Keyword::Continue) => self.parse_continue_stmt(),
@@ -1692,6 +1693,22 @@ impl<'src> Parser<'src> {
             kind: StmtKind::While { cond, body },
             span: Span {
                 range: while_tok.span.range.start..end,
+            },
+        })
+    }
+
+    fn parse_loop_stmt(&mut self) -> Option<Stmt> {
+        let loop_tok = self.advance().clone(); // consume `loop`
+        let body = self.parse_block().unwrap_or(Block {
+            stmts: Vec::new(),
+            span: self.ast_span_from(&loop_tok.span),
+        });
+
+        let end = body.span.range.end;
+        Some(Stmt {
+            kind: StmtKind::Loop { body },
+            span: Span {
+                range: loop_tok.span.range.start..end,
             },
         })
     }

--- a/crates/husk-parser/src/lib.rs
+++ b/crates/husk-parser/src/lib.rs
@@ -3498,4 +3498,66 @@ mod tests {
             panic!("expected Fn item");
         }
     }
+
+    #[test]
+    fn parses_loop_statement() {
+        let src = r#"fn main() { loop { break; } }"#;
+        let result = parse_str(src);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        let file = result.file.unwrap();
+        if let ItemKind::Fn { body, .. } = &file.items[0].kind {
+            assert_eq!(body.len(), 1);
+            if let StmtKind::Loop { body: loop_body } = &body[0].kind {
+                assert_eq!(loop_body.stmts.len(), 1);
+                assert!(matches!(loop_body.stmts[0].kind, StmtKind::Break));
+            } else {
+                panic!("expected Loop statement, got {:?}", body[0].kind);
+            }
+        } else {
+            panic!("expected Fn item");
+        }
+    }
+
+    #[test]
+    fn parses_loop_with_continue() {
+        let src = r#"fn main() { loop { continue; } }"#;
+        let result = parse_str(src);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        let file = result.file.unwrap();
+        if let ItemKind::Fn { body, .. } = &file.items[0].kind {
+            if let StmtKind::Loop { body: loop_body } = &body[0].kind {
+                assert_eq!(loop_body.stmts.len(), 1);
+                assert!(matches!(loop_body.stmts[0].kind, StmtKind::Continue));
+            } else {
+                panic!("expected Loop statement");
+            }
+        } else {
+            panic!("expected Fn item");
+        }
+    }
+
+    #[test]
+    fn parses_loop_with_if_break() {
+        let src = r#"fn main() {
+            loop {
+                if true {
+                    break;
+                }
+            }
+        }"#;
+        let result = parse_str(src);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        let file = result.file.unwrap();
+        if let ItemKind::Fn { body, .. } = &file.items[0].kind {
+            assert_eq!(body.len(), 1);
+            if let StmtKind::Loop { body: loop_body } = &body[0].kind {
+                assert_eq!(loop_body.stmts.len(), 1);
+                assert!(matches!(loop_body.stmts[0].kind, StmtKind::If { .. }));
+            } else {
+                panic!("expected Loop statement");
+            }
+        } else {
+            panic!("expected Fn item");
+        }
+    }
 }

--- a/crates/husk-semantic/src/lib.rs
+++ b/crates/husk-semantic/src/lib.rs
@@ -3233,4 +3233,123 @@ fn main() {
             result.type_errors
         );
     }
+
+    #[test]
+    fn loop_allows_break_inside() {
+        let src = r#"
+fn main() {
+    loop {
+        break;
+    }
+}
+"#;
+        let parsed = parse_str(src);
+        assert!(
+            parsed.errors.is_empty(),
+            "parse errors: {:?}",
+            parsed.errors
+        );
+        let file = parsed.file.expect("parser produced no AST");
+        let result = analyze_file(&file);
+        assert!(
+            result.type_errors.is_empty(),
+            "unexpected type errors: {:?}",
+            result.type_errors
+        );
+    }
+
+    #[test]
+    fn loop_allows_continue_inside() {
+        let src = r#"
+fn main() {
+    loop {
+        continue;
+    }
+}
+"#;
+        let parsed = parse_str(src);
+        assert!(
+            parsed.errors.is_empty(),
+            "parse errors: {:?}",
+            parsed.errors
+        );
+        let file = parsed.file.expect("parser produced no AST");
+        let result = analyze_file(&file);
+        assert!(
+            result.type_errors.is_empty(),
+            "unexpected type errors: {:?}",
+            result.type_errors
+        );
+    }
+
+    #[test]
+    fn break_outside_loop_reports_error() {
+        let src = r#"
+fn main() {
+    break;
+}
+"#;
+        let parsed = parse_str(src);
+        assert!(
+            parsed.errors.is_empty(),
+            "parse errors: {:?}",
+            parsed.errors
+        );
+        let file = parsed.file.expect("parser produced no AST");
+        let result = analyze_file(&file);
+        assert!(
+            result.type_errors.iter().any(|e| e.message.contains("`break` used outside of loop")),
+            "expected break outside loop error, got: {:?}",
+            result.type_errors
+        );
+    }
+
+    #[test]
+    fn continue_outside_loop_reports_error() {
+        let src = r#"
+fn main() {
+    continue;
+}
+"#;
+        let parsed = parse_str(src);
+        assert!(
+            parsed.errors.is_empty(),
+            "parse errors: {:?}",
+            parsed.errors
+        );
+        let file = parsed.file.expect("parser produced no AST");
+        let result = analyze_file(&file);
+        assert!(
+            result.type_errors.iter().any(|e| e.message.contains("`continue` used outside of loop")),
+            "expected continue outside loop error, got: {:?}",
+            result.type_errors
+        );
+    }
+
+    #[test]
+    fn nested_loop_allows_break() {
+        let src = r#"
+fn main() {
+    loop {
+        loop {
+            break;
+        }
+        break;
+    }
+}
+"#;
+        let parsed = parse_str(src);
+        assert!(
+            parsed.errors.is_empty(),
+            "parse errors: {:?}",
+            parsed.errors
+        );
+        let file = parsed.file.expect("parser produced no AST");
+        let result = analyze_file(&file);
+        assert!(
+            result.type_errors.is_empty(),
+            "unexpected type errors: {:?}",
+            result.type_errors
+        );
+    }
 }

--- a/crates/husk-semantic/src/lib.rs
+++ b/crates/husk-semantic/src/lib.rs
@@ -1196,6 +1196,12 @@ impl<'a> FnContext<'a> {
                 self.check_block(body);
                 self.in_loop = prev_in_loop;
             }
+            StmtKind::Loop { body } => {
+                let prev_in_loop = self.in_loop;
+                self.in_loop = true;
+                self.check_block(body);
+                self.in_loop = prev_in_loop;
+            }
             StmtKind::ForIn {
                 binding,
                 iterable,

--- a/syntax.md
+++ b/syntax.md
@@ -135,6 +135,13 @@ Inside function bodies and blocks:
       break;
       continue;
   }
+
+  loop {
+      // infinite loop, exit with break or return
+      if condition {
+          break;
+      }
+  }
   ```
 
 ## 8. Expressions


### PR DESCRIPTION
## Summary

- Add support for Rust-style `loop` keyword that creates infinite loops
- The loop can only be exited via `break` or `return`
- Also implements proper codegen for `while`, `break`, and `continue` (previously returned `undefined`)

## Changes

- **Lexer**: add `loop` keyword recognition
- **AST**: add `Loop { body }` variant to StmtKind
- **Parser**: parse `loop { ... }` syntax
- **Semantic**: type-check loop bodies, validate break/continue
- **Formatter**: format loop statements
- **Codegen**: generate JavaScript `while(true) { ... }`

## Example

```rust
fn main() {
    let mut count = 0;
    loop {
        count = count + 1;
        if count >= 5 {
            break;
        }
    }
    println("Count: {}", count);
}
```

Compiles to:

```javascript
function main() {
    let count = 0;
    while (true) {
        count = count + 1;
        if (count >= 5) {
            break;
        }
    }
    console.log("Count: " + __husk_fmt(count));
}
```

## Test plan

- [x] All existing tests pass
- [x] Manual testing of loop with break
- [x] Manual testing of loop with continue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a native infinite loop construct (`loop`) with support for `break`/`continue`.
  * End-to-end support across parsing, semantic checks, formatting, and JavaScript code generation.

* **Tests**
  * Added unit tests validating parsing, lowering/printing, and formatting of loop, break, and continue scenarios.

* **Documentation**
  * Updated language syntax docs with a `loop { ... }` example demonstrating break-based exit.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->