### PR TITLE
feat: support Rust-style named variable interpolation in format strings

### DIFF
--- a/crates/husk-semantic/src/lib.rs
+++ b/crates/husk-semantic/src/lib.rs
@@ -1757,29 +1757,26 @@ impl<'a> FnContext<'a> {
                     }
                 }
 
-                // Check for mixing positional and implicit indexing
-                let has_explicit_position = placeholders.iter().any(|ph| ph.position.is_some());
+                // Check for mixing explicit numeric positions (like {0}) with implicit positions ({}).
+                // Named placeholders like {x} are allowed to mix with implicit {} since the parser
+                // synthesizes arguments for them separately.
+                let has_explicit_numeric_position = placeholders
+                    .iter()
+                    .any(|ph| ph.position.is_some() && ph.name.is_none());
                 let has_implicit_position = placeholders
                     .iter()
                     .any(|ph| ph.position.is_none() && ph.name.is_none());
 
-                if has_explicit_position && has_implicit_position {
+                if has_explicit_numeric_position && has_implicit_position {
                     self.tcx.errors.push(SemanticError {
                         message: "cannot mix positional and implicit argument indexing".to_string(),
                         span: format.span.clone(),
                     });
                 }
 
-                // Check for named arguments (which require matching argument names - not yet supported)
-                let has_named = placeholders.iter().any(|ph| ph.name.is_some());
-                if has_named {
-                    self.tcx.errors.push(SemanticError {
-                        message: "named format arguments are not yet supported".to_string(),
-                        span: format.span.clone(),
-                    });
-                }
-
                 // Validate argument count
+                // Named placeholders have synthesized arguments with explicit positions
+                let has_explicit_position = placeholders.iter().any(|ph| ph.position.is_some());
                 if has_explicit_position {
                     // With explicit positions, check that all indices are in bounds
                     for ph in &placeholders {
@@ -1852,26 +1849,25 @@ impl<'a> FnContext<'a> {
                     }
                 }
 
-                let has_explicit_position = placeholders.iter().any(|ph| ph.position.is_some());
+                // Check for mixing explicit numeric positions (like {0}) with implicit positions ({}).
+                // Named placeholders like {x} are allowed to mix with implicit {} since the parser
+                // synthesizes arguments for them separately.
+                let has_explicit_numeric_position = placeholders
+                    .iter()
+                    .any(|ph| ph.position.is_some() && ph.name.is_none());
                 let has_implicit_position = placeholders
                     .iter()
                     .any(|ph| ph.position.is_none() && ph.name.is_none());
 
-                if has_explicit_position && has_implicit_position {
+                if has_explicit_numeric_position && has_implicit_position {
                     self.tcx.errors.push(SemanticError {
                         message: "cannot mix positional and implicit argument indexing".to_string(),
                         span: format.span.clone(),
                     });
                 }
 
-                let has_named = placeholders.iter().any(|ph| ph.name.is_some());
-                if has_named {
-                    self.tcx.errors.push(SemanticError {
-                        message: "named format arguments are not yet supported".to_string(),
-                        span: format.span.clone(),
-                    });
-                }
-
+                // Named placeholders have synthesized arguments with explicit positions
+                let has_explicit_position = placeholders.iter().any(|ph| ph.position.is_some());
                 if has_explicit_position {
                     for ph in &placeholders {
                         if let Some(pos) = ph.position {


### PR DESCRIPTION
## Summary

- Add support for `{var_name}` syntax in `print`, `println`, and `format` functions
- Variables are automatically captured from the local scope, just like Rust's format strings
- Named placeholders can be mixed with implicit `{}` placeholders
- Format specifiers work with named placeholders (e.g., `{x:08x}`)

### Examples

```husk
let name = "World";
let x = 42;
println("{name}");              // prints: World
println("x = {x}");             // prints: x = 42
println("{x} + {x} = {}", x + x);  // prints: 42 + 42 = 84
println("{x:08x}");             // prints: 0000002a
```

### Implementation

The parser now synthesizes implicit identifier arguments for named placeholders and assigns them explicit positions. This approach reuses the existing codegen infrastructure without changes.

## Test plan

- [x] Added 6 new parser tests for named placeholder syntax
- [x] All existing tests pass
- [x] Manual testing with example code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic synthesis of arguments for named format placeholders (e.g., {name} now generates and reuses argument positions).

* **Improvements**
  * Format validation updated to allow named placeholders to mix with implicit positions while still preventing mixing of explicit numeric and implicit positions.

* **Tests**
  * Added tests covering named-placeholder synthesis, reuse, mixed explicit/implicit scenarios, and format-spec interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->