### PR TITLE
feat: add PartialEq and Eq traits with trait bound enforcement

### DIFF
--- a/crates/husk-ast/src/lib.rs
+++ b/crates/husk-ast/src/lib.rs
@@ -411,7 +411,7 @@ pub struct ClosureParam {
 pub enum ItemKind {
     Fn {
         name: Ident,
-        type_params: Vec<Ident>,
+        type_params: Vec<TypeParam>,
         params: Vec<Param>,
         ret_type: Option<TypeExpr>,
         body: Vec<Stmt>,
@@ -448,11 +448,13 @@ pub enum ItemKind {
 // Trait and Impl AST Nodes
 // ============================================================================
 
-/// A trait definition: `trait Name { fn method(&self); }`
+/// A trait definition: `trait Name: SuperTrait { fn method(&self); }`
 #[derive(Debug, Clone, PartialEq)]
 pub struct TraitDef {
     pub name: Ident,
     pub type_params: Vec<TypeParam>,
+    /// Supertraits that this trait requires (e.g., `Eq: PartialEq` means PartialEq is a supertrait)
+    pub supertraits: Vec<TypeExpr>,
     pub items: Vec<TraitItem>,
     pub span: Span,
 }

--- a/crates/husk-fmt/src/visitor.rs
+++ b/crates/husk-fmt/src/visitor.rs
@@ -262,7 +262,7 @@ impl<'a> Formatter<'a> {
     fn format_fn(
         &mut self,
         name: &Ident,
-        type_params: &[Ident],
+        type_params: &[TypeParam],
         params: &[Param],
         ret_type: &Option<TypeExpr>,
         body: &[Stmt],
@@ -275,14 +275,24 @@ impl<'a> Formatter<'a> {
         self.write("fn ");
         self.write(&name.name);
 
-        // Type parameters
+        // Type parameters with optional bounds
         if !type_params.is_empty() {
             self.write("<");
             for (i, tp) in type_params.iter().enumerate() {
                 if i > 0 {
                     self.write(", ");
                 }
-                self.write(&tp.name);
+                self.write(&tp.name.name);
+                // Format trait bounds: `T: Foo + Bar`
+                if !tp.bounds.is_empty() {
+                    self.write(": ");
+                    for (j, bound) in tp.bounds.iter().enumerate() {
+                        if j > 0 {
+                            self.write(" + ");
+                        }
+                        self.format_type(bound);
+                    }
+                }
             }
             self.write(">");
         }
@@ -621,6 +631,17 @@ impl<'a> Formatter<'a> {
                 }
             }
             self.write(">");
+        }
+
+        // Format supertraits: `trait Eq: PartialEq + Clone`
+        if !trait_def.supertraits.is_empty() {
+            self.write(": ");
+            for (i, supertrait) in trait_def.supertraits.iter().enumerate() {
+                if i > 0 {
+                    self.write(" + ");
+                }
+                self.format_type(supertrait);
+            }
         }
 
         self.write(" {");

--- a/crates/husk-semantic/src/lib.rs
+++ b/crates/husk-semantic/src/lib.rs
@@ -395,10 +395,17 @@ impl TypeEnv {
     /// 2. For supertraits, checks if all required supertraits are also implemented
     ///
     /// Returns true if the type implements the trait (including via supertrait satisfaction).
+    ///
+    /// Note: For generic types like `Vec<i32>`, we also check the base type `Vec`
+    /// since impls are registered on the base struct name.
     fn type_implements_trait(&self, type_name: &str, trait_name: &str) -> bool {
+        // Extract base type name for generic types (e.g., "Vec<i32>" -> "Vec")
+        let base_type_name = type_name.split('<').next().unwrap_or(type_name);
+
         // Check for direct trait implementation
         for impl_info in &self.impls {
-            if impl_info.self_ty_name == type_name {
+            // Match either the exact type name or the base type for generics
+            if impl_info.self_ty_name == type_name || impl_info.self_ty_name == base_type_name {
                 if let Some(ref impl_trait) = impl_info.trait_name {
                     if impl_trait == trait_name {
                         return true;

--- a/stdlib/core.hk
+++ b/stdlib/core.hk
@@ -17,6 +17,50 @@ enum Result<T, E> {
     Err(E),
 }
 
+// ============================================================================
+// Comparison Traits
+// ============================================================================
+
+// Trait for partial equality comparisons.
+//
+// Types implementing PartialEq can be compared for equality, but the
+// comparison may not be reflexive (e.g., NaN != NaN for floating point).
+//
+// Note: This is a marker trait in Husk. The actual equality comparison
+// is performed by the runtime using JavaScript's strict equality (===)
+// for primitives and deep equality (__husk_eq) for complex types.
+trait PartialEq {}
+
+// Trait for full equivalence relations.
+//
+// Types implementing Eq guarantee that equality is:
+// - Reflexive: a == a
+// - Symmetric: a == b implies b == a
+// - Transitive: a == b and b == c implies a == c
+//
+// Eq requires PartialEq as a supertrait. Types that implement Eq must
+// also implement PartialEq.
+//
+// Note: f64 implements PartialEq but NOT Eq because NaN != NaN.
+trait Eq: PartialEq {}
+
+// ============================================================================
+// Primitive PartialEq implementations
+// ============================================================================
+
+impl PartialEq for i32 {}
+impl PartialEq for f64 {}
+impl PartialEq for bool {}
+impl PartialEq for String {}
+
+// ============================================================================
+// Primitive Eq implementations (not f64 due to NaN != NaN)
+// ============================================================================
+
+impl Eq for i32 {}
+impl Eq for bool {}
+impl Eq for String {}
+
 // Built-in functions for console output.
 // These are translated to console.log/console.error in JavaScript.
 extern "js" {

--- a/syntax.md
+++ b/syntax.md
@@ -11,6 +11,8 @@ This document summarizes the concrete surface syntax supported in the Husk MVP. 
   - Function definitions: `fn`
   - Struct definitions: `struct`
   - Enum definitions: `enum`
+  - Trait definitions: `trait`
+  - Impl blocks: `impl`
   - Type aliases: `type`
   - Extern JS declarations: `extern "js" { ... }`
 
@@ -233,7 +235,7 @@ Type forms in MVP:
   ()
   ```
 
-No references (`&T`), lifetimes, or trait bounds in MVP.
+No references (`&T`) or lifetimes in MVP. See section 11 for trait bounds.
 
 ## 10. Pattern Matching
 
@@ -274,3 +276,207 @@ Supported patterns:
   ```
 
 Pattern guards (`if` in patterns) and or-patterns (`A | B`) are out of MVP.
+
+## 11. Traits and Trait Bounds
+
+### 11.1 Trait Definitions
+
+Traits define shared behavior that types can implement:
+
+```rust
+trait Greet {
+    fn greet(&self) -> String;
+}
+
+// Trait with default implementation
+trait Debug {
+    fn debug(&self) -> String {
+        "[object]"
+    }
+}
+```
+
+### 11.2 Supertraits
+
+Traits can require other traits as prerequisites using the supertrait syntax:
+
+```rust
+trait PartialEq {}
+trait Eq: PartialEq {}  // Eq requires PartialEq
+```
+
+When implementing a trait with supertraits, all supertraits must also be implemented:
+
+```rust
+struct Point { x: i32, y: i32 }
+
+impl PartialEq for Point {}  // Must implement PartialEq first
+impl Eq for Point {}         // Now Eq can be implemented
+```
+
+### 11.3 Impl Blocks
+
+Implement methods for a type (inherent impl) or implement a trait for a type:
+
+```rust
+// Inherent impl - methods belong to the type itself
+impl Point {
+    fn new(x: i32, y: i32) -> Point {
+        Point { x, y }
+    }
+
+    fn distance(&self) -> f64 {
+        // ...
+    }
+}
+
+// Trait impl - implement trait for a type
+impl Greet for Point {
+    fn greet(&self) -> String {
+        "Hello from Point!"
+    }
+}
+```
+
+### 11.4 Trait Bounds on Functions
+
+Generic functions can require type parameters to implement specific traits:
+
+```rust
+fn compare<T: PartialEq>(a: T, b: T) -> bool {
+    a == b
+}
+
+// Multiple bounds with + syntax (not yet supported)
+// fn print_and_compare<T: PartialEq + Debug>(a: T, b: T) { ... }
+```
+
+The compiler enforces trait bounds at call sites:
+
+```rust
+compare(1, 2);      // OK: i32 implements PartialEq
+compare(p1, p2);    // Error if Point doesn't implement PartialEq
+```
+
+## 12. Standard Library Traits
+
+### 12.1 PartialEq
+
+The `PartialEq` trait enables equality comparisons (`==` and `!=`):
+
+```rust
+trait PartialEq {}
+```
+
+Types implementing `PartialEq` can be compared for equality, but the comparison
+may not be reflexive (e.g., `NaN != NaN` for floating point).
+
+**Primitive implementations:**
+- `i32` - implements PartialEq
+- `f64` - implements PartialEq (but not Eq due to NaN)
+- `bool` - implements PartialEq
+- `String` - implements PartialEq
+
+### 12.2 Eq
+
+The `Eq` trait guarantees a full equivalence relation:
+
+```rust
+trait Eq: PartialEq {}
+```
+
+Types implementing `Eq` guarantee that equality is:
+- **Reflexive:** `a == a` is always true
+- **Symmetric:** `a == b` implies `b == a`
+- **Transitive:** `a == b` and `b == c` implies `a == c`
+
+**Primitive implementations:**
+- `i32` - implements Eq
+- `bool` - implements Eq
+- `String` - implements Eq
+- `f64` - does NOT implement Eq (because `NaN != NaN`)
+
+### 12.3 Implementing Traits for Custom Types
+
+```rust
+struct Point { x: i32, y: i32 }
+
+impl PartialEq for Point {}
+impl Eq for Point {}  // Requires PartialEq to be implemented first
+```
+
+## 13. Testing and Assertions
+
+Husk provides built-in assertion functions for testing:
+
+### 13.1 assert
+
+Asserts that a condition is true. Panics if the condition is false:
+
+```rust
+fn test_positive() {
+    let x = 5;
+    assert(x > 0);
+}
+```
+
+### 13.2 assert_msg
+
+Asserts with a custom error message:
+
+```rust
+fn test_bounds() {
+    let x = 10;
+    assert_msg(x < 100, "x must be less than 100");
+}
+```
+
+### 13.3 assert_eq
+
+Asserts that two values are equal. Panics with a detailed message showing both values if they differ:
+
+```rust
+fn test_addition() {
+    let result = 2 + 2;
+    assert_eq(result, 4);
+}
+
+fn test_string() {
+    let s = "hello";
+    assert_eq(s, "hello");
+}
+```
+
+### 13.4 assert_ne
+
+Asserts that two values are NOT equal. Panics if they are equal:
+
+```rust
+fn test_different() {
+    let a = 1;
+    let b = 2;
+    assert_ne(a, b);
+}
+```
+
+### 13.5 Writing Tests
+
+Tests are functions marked with the `#[test]` attribute:
+
+```rust
+#[test]
+fn test_point_creation() {
+    let p = Point { x: 10, y: 20 };
+    assert_eq(p.x, 10);
+    assert_eq(p.y, 20);
+}
+
+#[test]
+fn test_equality() {
+    let p1 = Point { x: 1, y: 2 };
+    let p2 = Point { x: 1, y: 2 };
+    assert_eq(p1, p2);
+}
+```
+
+Run tests with `husk test` or `husk test path/to/file.hk`.


### PR DESCRIPTION
## Summary

- Add `PartialEq` and `Eq` marker traits to the stdlib with supertrait support (`trait Eq: PartialEq {}`)
- Implement trait bound parsing on function type parameters (e.g., `fn compare<T: PartialEq>()`)
- Enforce trait bounds at function call sites during semantic analysis
- Enforce supertrait requirements when implementing traits (e.g., can't `impl Eq` without `impl PartialEq`)
- Add special handling for `assert_eq` and `assert_ne` to require `PartialEq` on arguments
- Add primitive trait implementations for `i32`, `f64`, `bool`, and `String`

## Test plan

- [x] All 22 semantic analysis tests pass
- [x] 6 new unit tests for trait bound enforcement:
  - `test_trait_bound_satisfied` - basic trait bound satisfaction
  - `test_trait_bound_not_satisfied` - error when bound not met
  - `test_supertrait_not_implemented` - error when implementing trait without supertrait
  - `test_supertrait_implemented` - success when supertrait is present
  - `test_assert_eq_with_partial_eq` - assert_eq works with PartialEq types
  - `test_assert_eq_without_partial_eq` - assert_eq fails without PartialEq
- [x] End-to-end testing confirms proper error messages for missing trait bounds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trait supertraits: traits can inherit other traits (e.g., Eq: PartialEq).
  * Generic type parameter bounds: constrain generics in functions and traits (e.g., T: Foo + Bar).
  * Standard library comparison traits: added PartialEq and Eq; PartialEq for i32, f64, bool, String; Eq for i32, bool, String.

* **Formatting**
  * Formatter prints type parameter bounds and trait supertraits.

* **Behavior**
  * Type checker enforces generic trait bounds and reports missing supertraits.

* **Tests**
  * New tests for trait bounds, supertraits, and resolution scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->