### PR TITLE
feat: implement `as` keyword for primitive type casting

### DIFF
--- a/crates/husk-ast/src/lib.rs
+++ b/crates/husk-ast/src/lib.rs
@@ -200,6 +200,11 @@ pub enum ExprKind {
         /// The raw JavaScript code (content between braces, trimmed)
         code: String,
     },
+    /// Type cast expression: `expr as Type`
+    Cast {
+        expr: Box<Expr>,
+        target_ty: TypeExpr,
+    },
 }
 
 // ============================================================================

--- a/crates/husk-fmt/src/visitor.rs
+++ b/crates/husk-fmt/src/visitor.rs
@@ -1321,6 +1321,11 @@ impl<'a> Formatter<'a> {
                 self.write(code);
                 self.write(" }");
             }
+            ExprKind::Cast { expr, target_ty } => {
+                self.format_expr(expr);
+                self.write(" as ");
+                self.format_type(target_ty);
+            }
         }
     }
 

--- a/crates/husk-parser/src/lib.rs
+++ b/crates/husk-parser/src/lib.rs
@@ -2016,10 +2016,10 @@ impl<'src> Parser<'src> {
     }
 
     /// Parse cast expressions: `expr as Type`
-    /// Cast has higher precedence than arithmetic operators (+, -, *, /, %)
-    /// so `2 + 3 as f64` parses as `2 + (3 as f64)`.
+    /// Cast has higher precedence than all arithmetic operators (+, -, *, /, %)
+    /// so `2 + 3 as f64` parses as `2 + (3 as f64)` and `2 * 3 as f64` as `2 * (3 as f64)`.
     fn parse_cast(&mut self) -> Option<Expr> {
-        let mut expr = self.parse_multiplicative()?;
+        let mut expr = self.parse_unary()?;
 
         loop {
             if self.matches_keyword(Keyword::As) {
@@ -2043,7 +2043,7 @@ impl<'src> Parser<'src> {
     }
 
     fn parse_additive(&mut self) -> Option<Expr> {
-        let mut expr = self.parse_cast()?;
+        let mut expr = self.parse_multiplicative()?;
         loop {
             let op = if self.matches_token(&TokenKind::Plus) {
                 Some(BinaryOp::Add)
@@ -2054,7 +2054,7 @@ impl<'src> Parser<'src> {
             };
 
             if let Some(op) = op {
-                let right = self.parse_cast()?;
+                let right = self.parse_multiplicative()?;
                 let span = Span {
                     range: expr.span.range.start..right.span.range.end,
                 };
@@ -2074,7 +2074,7 @@ impl<'src> Parser<'src> {
     }
 
     fn parse_multiplicative(&mut self) -> Option<Expr> {
-        let mut expr = self.parse_unary()?;
+        let mut expr = self.parse_cast()?;
         loop {
             let op = if self.matches_token(&TokenKind::Star) {
                 Some(BinaryOp::Mul)
@@ -2087,7 +2087,7 @@ impl<'src> Parser<'src> {
             };
 
             if let Some(op) = op {
-                let right = self.parse_unary()?;
+                let right = self.parse_cast()?;
                 let span = Span {
                     range: expr.span.range.start..right.span.range.end,
                 };
@@ -4152,6 +4152,50 @@ mod tests {
                             assert_eq!(ident.name, "i32");
                         } else {
                             panic!("expected type i32");
+                        }
+                    } else {
+                        panic!("expected Cast on right");
+                    }
+                } else {
+                    panic!("expected Binary expression");
+                }
+            } else {
+                panic!("expected Let statement with value");
+            }
+        } else {
+            panic!("expected Fn item");
+        }
+    }
+
+    #[test]
+    fn parses_cast_with_multiplication_precedence() {
+        // Cast should have higher precedence than multiplication, so "2 * 3 as f64" should parse as "2 * (3 as f64)"
+        let src = r#"fn main() { let x = 2 * 3 as f64; }"#;
+        let result = parse_str(src);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        let file = result.file.unwrap();
+        if let ItemKind::Fn { body, .. } = &file.items[0].kind {
+            if let husk_ast::StmtKind::Let { value: Some(val), .. } = &body[0].kind {
+                // Should be: Binary(Mul, 2, Cast(3, f64))
+                if let ExprKind::Binary { op, left, right } = &val.kind {
+                    assert!(matches!(op, husk_ast::BinaryOp::Mul));
+                    // Left should be 2
+                    if let ExprKind::Literal(lit) = &left.kind {
+                        assert!(matches!(lit.kind, husk_ast::LiteralKind::Int(2)));
+                    } else {
+                        panic!("expected Literal 2 on left");
+                    }
+                    // Right should be Cast(3, f64)
+                    if let ExprKind::Cast { expr, target_ty } = &right.kind {
+                        if let ExprKind::Literal(lit) = &expr.kind {
+                            assert!(matches!(lit.kind, husk_ast::LiteralKind::Int(3)));
+                        } else {
+                            panic!("expected Literal 3 in cast");
+                        }
+                        if let husk_ast::TypeExprKind::Named(ident) = &target_ty.kind {
+                            assert_eq!(ident.name, "f64");
+                        } else {
+                            panic!("expected type f64");
                         }
                     } else {
                         panic!("expected Cast on right");

--- a/crates/husk-semantic/src/lib.rs
+++ b/crates/husk-semantic/src/lib.rs
@@ -2300,7 +2300,7 @@ impl<'a> FnContext<'a> {
                         Type::Primitive(PrimitiveType::F64),
                     ) => true,
 
-                    // Anything to String
+                    // Primitives to String
                     (
                         Type::Primitive(PrimitiveType::I32),
                         Type::Primitive(PrimitiveType::String),
@@ -2314,8 +2314,14 @@ impl<'a> FnContext<'a> {
                         Type::Primitive(PrimitiveType::String),
                     ) => true,
 
-                    // Same type (no-op, but allowed)
-                    (a, b) if a == b => true,
+                    // Same type (no-op, but allowed) - exclude bool since codegen
+                    // doesn't support casting to bool
+                    (a, b)
+                        if a == b
+                            && !matches!(b, Type::Primitive(PrimitiveType::Bool)) =>
+                    {
+                        true
+                    }
 
                     _ => false,
                 };

--- a/crates/husk-semantic/src/lib.rs
+++ b/crates/husk-semantic/src/lib.rs
@@ -2340,11 +2340,17 @@ impl<'a> FnContext<'a> {
 
                     let message = if let Some(hint) = hint {
                         format!(
-                            "cannot cast `{:?}` to `{:?}`; {}",
-                            inner_ty, target, hint
+                            "cannot cast `{}` to `{}`; {}",
+                            self.format_type(&inner_ty),
+                            self.format_type(&target),
+                            hint
                         )
                     } else {
-                        format!("cannot cast `{:?}` to `{:?}`", inner_ty, target)
+                        format!(
+                            "cannot cast `{}` to `{}`",
+                            self.format_type(&inner_ty),
+                            self.format_type(&target)
+                        )
                     };
 
                     self.tcx.errors.push(SemanticError {

--- a/examples/cast_expressions.hk
+++ b/examples/cast_expressions.hk
@@ -1,0 +1,44 @@
+// Test file for type cast expressions
+
+fn main() {
+    // i32 to f64 (widening)
+    let a: f64 = 42 as f64;
+    println("i32 to f64: {a}");
+
+    // f64 to i32 (truncation)
+    let b: i32 = 3.14 as i32;
+    println("f64 to i32 (3.14): {b}");
+
+    // Test with positive floats only (negative float support is limited)
+    let c: i32 = 9.99 as i32;
+    println("f64 to i32 (9.99): {c}");
+
+    // bool to i32
+    let d: i32 = true as i32;
+    let e: i32 = false as i32;
+    println("bool to i32: true={d}, false={e}");
+
+    // bool to f64
+    let f: f64 = true as f64;
+    let g: f64 = false as f64;
+    println("bool to f64: true={f}, false={g}");
+
+    // any to String
+    let h: String = 42 as String;
+    let i: String = 3.14 as String;
+    let j: String = true as String;
+    println("to String: i32={h}, f64={i}, bool={j}");
+
+    // Chained casts
+    let k: f64 = true as i32 as f64;
+    println("chained (true as i32 as f64): {k}");
+
+    // Cast in expressions (precedence test)
+    // Note: Cast binds tighter than +, so we need parens to cast the sum
+    let m: f64 = (2 + 3) as f64;
+    println("(2 + 3) as f64: {m}");
+
+    // Same-type cast (no-op but allowed)
+    let n: i32 = 42 as i32;
+    println("same type: {n}");
+}


### PR DESCRIPTION
## Summary

- Add support for Rust-style type casting using the `as` keyword
- Allows explicit conversion between primitive types: i32 ↔ f64, bool → i32/f64, any → String
- Cast expressions bind tighter than arithmetic operators (`2 + 3 as f64` → `2 + (3 as f64)`)
- Disallowed casts (e.g., to bool) produce helpful error messages with suggestions

## Test plan

- [x] Parser tests for cast expressions and precedence
- [x] Integration test example (`examples/cast_expressions.hk`)
- [x] All existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add expression casting using "as" with proper precedence; runtime conversions implemented for common primitives and clear semantic errors for invalid casts.
* **Tests**
  * Expanded tests for parsing, precedence, chaining, and AST shape of casts.
* **Formatting**
  * Formatter outputs cast syntax ("as") consistently.
* **Examples**
  * New example demonstrating various cast scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->