### PR TITLE
feat: add String.parse() with bidirectional type inference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,6 +471,7 @@ dependencies = [
  "husk-ast",
  "husk-runtime-js",
  "husk-semantic",
+ "husk-types",
  "sourcemap",
 ]
 

--- a/crates/husk-ast/src/lib.rs
+++ b/crates/husk-ast/src/lib.rs
@@ -106,18 +106,29 @@ pub enum AssignOp {
     ModAssign, // %=
 }
 
+/// A segment in a path expression, optionally with type arguments (turbofish).
+/// Example: `Option` or `Option::<i32>` or `Result::<T, E>`
+#[derive(Debug, Clone, PartialEq)]
+pub struct PathSegment {
+    pub ident: Ident,
+    /// Optional type arguments via turbofish syntax: `Foo::<T, U>`
+    pub type_args: Option<Vec<TypeExpr>>,
+}
+
 /// Expressions.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ExprKind {
     Literal(Literal),
     Ident(Ident),
-    /// Path-like expression, e.g. `Enum::Variant`.
+    /// Path-like expression, e.g. `Enum::Variant` or `Enum::<T>::Variant`.
     /// For the MVP this is primarily used for enum constructors.
     Path {
-        segments: Vec<Ident>,
+        segments: Vec<PathSegment>,
     },
     Call {
         callee: Box<Expr>,
+        /// Optional type arguments via turbofish syntax: `foo::<T>()`
+        type_args: Option<Vec<TypeExpr>>,
         args: Vec<Expr>,
     },
     Field {
@@ -127,6 +138,8 @@ pub enum ExprKind {
     MethodCall {
         receiver: Box<Expr>,
         method: Ident,
+        /// Optional type arguments via turbofish syntax: `x.method::<T>()`
+        type_args: Option<Vec<TypeExpr>>,
         args: Vec<Expr>,
     },
     Unary {
@@ -489,6 +502,8 @@ pub enum TraitItemKind {
 #[derive(Debug, Clone, PartialEq)]
 pub struct TraitMethod {
     pub name: Ident,
+    /// Type parameters for generic methods: `fn parse<T>(&self) -> T`
+    pub type_params: Vec<TypeParam>,
     pub receiver: Option<SelfReceiver>,
     pub params: Vec<Param>,
     pub ret_type: Option<TypeExpr>,
@@ -572,6 +587,8 @@ impl ExternProperty {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ImplMethod {
     pub name: Ident,
+    /// Type parameters for generic methods: `fn parse<T>(&self) -> T`
+    pub type_params: Vec<TypeParam>,
     pub receiver: Option<SelfReceiver>,
     pub params: Vec<Param>,
     pub ret_type: Option<TypeExpr>,

--- a/crates/husk-codegen-js/Cargo.toml
+++ b/crates/husk-codegen-js/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2024"
 husk-ast = { path = "../husk-ast" }
 husk-runtime-js = { path = "../husk-runtime-js" }
 husk-semantic = { path = "../husk-semantic" }
+husk-types = { path = "../husk-types" }
 sourcemap = "9"

--- a/crates/husk-fmt/src/visitor.rs
+++ b/crates/husk-fmt/src/visitor.rs
@@ -1099,11 +1099,31 @@ impl<'a> Formatter<'a> {
                     if i > 0 {
                         self.write("::");
                     }
-                    self.write(&segment.name);
+                    self.write(&segment.ident.name);
+                    if let Some(ref type_args) = segment.type_args {
+                        self.write("::<");
+                        for (j, ty) in type_args.iter().enumerate() {
+                            if j > 0 {
+                                self.write(", ");
+                            }
+                            self.format_type(ty);
+                        }
+                        self.write(">");
+                    }
                 }
             }
-            ExprKind::Call { callee, args } => {
+            ExprKind::Call { callee, type_args, args } => {
                 self.format_expr(callee);
+                if let Some(targs) = type_args {
+                    self.write("::<");
+                    for (i, ty) in targs.iter().enumerate() {
+                        if i > 0 {
+                            self.write(", ");
+                        }
+                        self.format_type(ty);
+                    }
+                    self.write(">");
+                }
                 self.write("(");
                 for (i, arg) in args.iter().enumerate() {
                     if i > 0 {
@@ -1121,11 +1141,22 @@ impl<'a> Formatter<'a> {
             ExprKind::MethodCall {
                 receiver,
                 method,
+                type_args,
                 args,
             } => {
                 self.format_expr(receiver);
                 self.write(".");
                 self.write(&method.name);
+                if let Some(targs) = type_args {
+                    self.write("::<");
+                    for (i, ty) in targs.iter().enumerate() {
+                        if i > 0 {
+                            self.write(", ");
+                        }
+                        self.format_type(ty);
+                    }
+                    self.write(">");
+                }
                 self.write("(");
                 for (i, arg) in args.iter().enumerate() {
                     if i > 0 {

--- a/crates/husk-runtime-js/src/lib.rs
+++ b/crates/husk-runtime-js/src/lib.rs
@@ -23,7 +23,7 @@ function Ok(value) {
 }
 
 function Err(error) {
-    return { tag: "Err", error };
+    return { tag: "Err", value: error };
 }
 
 function panic(message) {
@@ -81,9 +81,6 @@ function __husk_fmt_debug(value, pretty) {
             if (keys.length === 0) return tag;
             if (keys.length === 1 && keys[0] === "value") {
                 return tag + "(" + __husk_fmt_debug(value.value, pretty) + ")";
-            }
-            if (keys.length === 1 && keys[0] === "error") {
-                return tag + "(" + __husk_fmt_debug(value.error, pretty) + ")";
             }
             // General struct fields
             var fields = keys.map(function(k) { return k + ": " + __husk_fmt_debug(value[k], pretty); });
@@ -400,7 +397,7 @@ function __husk_unwrap(value) {
             return value.value;
         }
         if (value.tag === "Err") {
-            throw new Error("[Husk panic] called unwrap on Err: " + __husk_fmt_debug(value.error));
+            throw new Error("[Husk panic] called unwrap on Err: " + __husk_fmt_debug(value.value));
         }
         if (value.tag === "Some") {
             return value.value;
@@ -423,7 +420,7 @@ function __husk_expect(value, message) {
             return value.value;
         }
         if (value.tag === "Err") {
-            throw new Error("[Husk panic] " + message + ": " + __husk_fmt_debug(value.error));
+            throw new Error("[Husk panic] " + message + ": " + __husk_fmt_debug(value.value));
         }
         if (value.tag === "Some") {
             return value.value;
@@ -434,6 +431,38 @@ function __husk_expect(value, message) {
     }
     // Not a Result/Option, return as-is
     return value;
+}
+
+// Parse a string to i32, returns Result<i32, String>
+function __husk_parse_i32(s) {
+    var n = parseInt(s, 10);
+    if (isNaN(n)) {
+        return Err("invalid integer: " + s);
+    }
+    if (n < -2147483648 || n > 2147483647) {
+        return Err("integer out of i32 range: " + s);
+    }
+    return Ok(n | 0);
+}
+
+// Parse a string to i64 (BigInt), returns Result<i64, String>
+function __husk_parse_i64(s) {
+    try {
+        var n = BigInt(s.trim());
+        return Ok(n);
+    } catch (e) {
+        return Err("invalid integer: " + s);
+    }
+}
+
+// Parse a string to f64, returns Result<f64, String>
+function __husk_parse_f64(s) {
+    var trimmed = s.trim();
+    var n = parseFloat(trimmed);
+    if (isNaN(n) && trimmed.toLowerCase() !== "nan") {
+        return Err("invalid float: " + s);
+    }
+    return Ok(n);
 }
 "#
 }

--- a/examples/string_parse.hk
+++ b/examples/string_parse.hk
@@ -1,0 +1,46 @@
+// Test String.parse::<T>() method with turbofish syntax
+
+fn main() {
+    // Test parsing i32
+    let result_i32: Result<i32, String> = "42".parse::<i32>();
+    match result_i32 {
+        Result::Ok(n) => println("Parsed i32: {}", n),
+        Result::Err(e) => println("Error: {}", e),
+    }
+
+    // Test parsing negative i32
+    let neg_result = "-123".parse::<i32>();
+    match neg_result {
+        Result::Ok(n) => println("Parsed negative i32: {}", n),
+        Result::Err(e) => println("Error: {}", e),
+    }
+
+    // Test parsing f64
+    let result_f64: Result<f64, String> = "3.14159".parse::<f64>();
+    match result_f64 {
+        Result::Ok(n) => println("Parsed f64: {}", n),
+        Result::Err(e) => println("Error: {}", e),
+    }
+
+    // Test parsing i64
+    let result_i64: Result<i64, String> = "9223372036854775807".parse::<i64>();
+    match result_i64 {
+        Result::Ok(n) => println("Parsed i64: {}", n),
+        Result::Err(e) => println("Error: {}", e),
+    }
+
+    // Test error case - invalid integer
+    let invalid = "not_a_number".parse::<i32>();
+    match invalid {
+        Result::Ok(n) => println("Should not get here: {}", n),
+        Result::Err(e) => println("Expected error: {}", e),
+    }
+
+    // Test chaining with unwrap
+    let x = "100".parse::<i32>().unwrap();
+    println("Parsed with unwrap: {}", x);
+
+    // Test chaining with expect
+    let y = "200".parse::<i32>().expect("failed to parse");
+    println("Parsed with expect: {}", y);
+}


### PR DESCRIPTION
## Summary
- Implement Rust-like turbofish syntax (`::&lt;T&gt;`) for explicit type parameters on method calls
- Add bidirectional type inference so types flow from annotations through method chains
- Enable patterns like `let x: i32 = "42".parse().unwrap()` without explicit turbofish
- Support parsing to i32, i64 (BigInt), and f64 types

## Changes

### Turbofish Syntax
- **AST**: Add `PathSegment` struct with optional `type_args` for turbofish support
- **Parser**: Handle `::<T>` syntax on method calls and path expressions

### Bidirectional Type Inference
- **Semantic**: Add `InferredGenerics` map to track inferred type parameters by span
- **Semantic**: Add `check_expr_with_expected()` for expected type threading
- **Semantic**: Implement expected type propagation through:
  - Let bindings (type annotations flow down)
  - Assignments (target type flows down)
  - Return statements (function return type flows down)
  - Match expressions and blocks (expected propagates to arms/final expr)
  - Method chains (`unwrap`/`expect` propagate expected through Result/Option)
  - Path expressions (`None`, `Ok`, `Err` infer types from context)

### Codegen & Runtime
- **Runtime**: Add `__husk_parse_i32`, `__husk_parse_i64`, `__husk_parse_f64` helpers
- **Codegen**: Use inferred types from semantic analysis when no turbofish present
- **CLI**: Plumb `inferred_generics` from semantic analysis to codegen

## Examples

```husk
// With turbofish (explicit)
let x = "42".parse::<i32>().unwrap();

// With type inference (new\!)
let y: i32 = "42".parse().unwrap();
let z: Result<i64, String> = "123".parse();
```

## Test plan
- [x] Parser tests for turbofish on method calls and function calls
- [x] Semantic tests for parse method type inference
- [x] Integration test `examples/string_parse.hk` covering:
  - Parsing i32, negative i32, f64, i64
  - Error case with invalid input
  - Chaining with `.unwrap()` and `.expect()`
- [x] Manual verification of type inference without turbofish
- [x] All existing tests pass (no regressions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added turbofish syntax support for specifying generic type arguments (e.g., parse::<i32>()) across parsing, formatting, and codegen.
  * String.parse now supports generic targets and new built-in parse helpers for i32, i64, and f64.

* **Formatting**
  * Formatter prints turbofish type arguments on paths, function calls, and method calls.

* **Tests / Examples**
  * New example and tests demonstrating turbofish parsing, numeric parsing success/failure, and method/function turbofish usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->