### PR TITLE
feat: add enum variant imports with use Enum::* syntax

### DIFF
--- a/crates/husk-ast/src/lib.rs
+++ b/crates/husk-ast/src/lib.rs
@@ -417,6 +417,17 @@ pub struct ClosureParam {
     pub ty: Option<TypeExpr>,
 }
 
+/// What kind of use import this is.
+#[derive(Debug, Clone, PartialEq)]
+pub enum UseKind {
+    /// Import the item at the path: `use crate::foo::Bar;`
+    Item,
+    /// Glob import all variants: `use Option::*;`
+    Glob,
+    /// Import specific variants: `use Result::{Ok, Err};` or `use Result::Ok;`
+    Variants(Vec<Ident>),
+}
+
 /// Item-level definitions.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ItemKind {
@@ -446,8 +457,10 @@ pub enum ItemKind {
         items: Vec<ExternItem>,
     },
     Use {
-        /// Path like `crate::foo::bar`
+        /// Path like `crate::foo::bar` or `Option` (for variant imports)
         path: Vec<Ident>,
+        /// What kind of import this is
+        kind: UseKind,
     },
     /// Trait definition: `trait Name { fn method(&self); }`
     Trait(TraitDef),

--- a/crates/husk-cli/src/main.rs
+++ b/crates/husk-cli/src/main.rs
@@ -503,13 +503,7 @@ fn run_compile(
     if source_map {
         // Generate with source map
         let source_path = Path::new(path);
-<<<<<<< HEAD
-        let module = lower_file_to_js_with_source(&file, !lib, js_target, Some(&content), Some(source_path), &semantic.name_resolution, &semantic.type_resolution);
-||||||| parent of 3915757 (feat: add enum variant imports with use Enum::* syntax)
-        let module = lower_file_to_js_with_source(&file, !lib, js_target, Some(&content), Some(source_path), &semantic.name_resolution);
-=======
-        let module = lower_file_to_js_with_source(&file, !lib, js_target, Some(&content), Some(source_path), &semantic.name_resolution, &semantic.variant_calls);
->>>>>>> 3915757 (feat: add enum variant imports with use Enum::* syntax)
+        let module = lower_file_to_js_with_source(&file, !lib, js_target, Some(&content), Some(source_path), &semantic.name_resolution, &semantic.type_resolution, &semantic.variant_calls, &semantic.variant_patterns);
         let source_file = Path::new(path)
             .file_name()
             .and_then(|s| s.to_str())
@@ -552,13 +546,7 @@ fn run_compile(
     } else {
         // Standard output (no source map)
         let source_path = Path::new(path);
-<<<<<<< HEAD
-        let module = lower_file_to_js_with_source(&file, !lib, js_target, None, Some(source_path), &semantic.name_resolution, &semantic.type_resolution);
-||||||| parent of 3915757 (feat: add enum variant imports with use Enum::* syntax)
-        let module = lower_file_to_js_with_source(&file, !lib, js_target, None, Some(source_path), &semantic.name_resolution);
-=======
-        let module = lower_file_to_js_with_source(&file, !lib, js_target, None, Some(source_path), &semantic.name_resolution, &semantic.variant_calls);
->>>>>>> 3915757 (feat: add enum variant imports with use Enum::* syntax)
+        let module = lower_file_to_js_with_source(&file, !lib, js_target, None, Some(source_path), &semantic.name_resolution, &semantic.type_resolution, &semantic.variant_calls, &semantic.variant_patterns);
         let js = module.to_source_with_preamble();
 
         if let Some(output_path) = output {
@@ -1071,12 +1059,9 @@ fn compile_to_file(path: &str, output: &str, target: Target, lib: bool, no_prelu
         Some(&content),
         Some(entry_path),
         &semantic.name_resolution,
-<<<<<<< HEAD
         &semantic.type_resolution,
-||||||| parent of 3915757 (feat: add enum variant imports with use Enum::* syntax)
-=======
         &semantic.variant_calls,
->>>>>>> 3915757 (feat: add enum variant imports with use Enum::* syntax)
+        &semantic.variant_patterns,
     );
     let js = module.to_source_with_preamble();
 
@@ -1301,13 +1286,7 @@ fn run_build(
 
     if source_map {
         // Generate with source map
-<<<<<<< HEAD
-        let module = lower_file_to_js_with_source(&filtered_ast, !lib, codegen_target, Some(&content), Some(&entry_path), &semantic.name_resolution, &semantic.type_resolution);
-||||||| parent of 3915757 (feat: add enum variant imports with use Enum::* syntax)
-        let module = lower_file_to_js_with_source(&filtered_ast, !lib, codegen_target, Some(&content), Some(&entry_path), &semantic.name_resolution);
-=======
-        let module = lower_file_to_js_with_source(&filtered_ast, !lib, codegen_target, Some(&content), Some(&entry_path), &semantic.name_resolution, &semantic.variant_calls);
->>>>>>> 3915757 (feat: add enum variant imports with use Enum::* syntax)
+        let module = lower_file_to_js_with_source(&filtered_ast, !lib, codegen_target, Some(&content), Some(&entry_path), &semantic.name_resolution, &semantic.type_resolution, &semantic.variant_calls, &semantic.variant_patterns);
         let source_file = entry_path
             .file_name()
             .and_then(|s| s.to_str())
@@ -1336,13 +1315,7 @@ fn run_build(
         }
     } else {
         // No source map
-<<<<<<< HEAD
-        let module = lower_file_to_js(&filtered_ast, !lib, codegen_target, &semantic.name_resolution, &semantic.type_resolution);
-||||||| parent of 3915757 (feat: add enum variant imports with use Enum::* syntax)
-        let module = lower_file_to_js(&filtered_ast, !lib, codegen_target, &semantic.name_resolution);
-=======
-        let module = lower_file_to_js(&filtered_ast, !lib, codegen_target, &semantic.name_resolution, &semantic.variant_calls);
->>>>>>> 3915757 (feat: add enum variant imports with use Enum::* syntax)
+        let module = lower_file_to_js(&filtered_ast, !lib, codegen_target, &semantic.name_resolution, &semantic.type_resolution, &semantic.variant_calls, &semantic.variant_patterns);
         let js = module.to_source_with_preamble();
 
         if let Err(err) = fs::write(&js_file, &js) {
@@ -1607,13 +1580,7 @@ fn run_test(
 
     // Compile to JS with lib mode (don't auto-call main)
     let source_path = Path::new(&path);
-<<<<<<< HEAD
-    let module = lower_file_to_js_with_source(&file_ast, false, JsTarget::Cjs, None, Some(source_path), &semantic.name_resolution, &semantic.type_resolution);
-||||||| parent of 3915757 (feat: add enum variant imports with use Enum::* syntax)
-    let module = lower_file_to_js_with_source(&file_ast, false, JsTarget::Cjs, None, Some(source_path), &semantic.name_resolution);
-=======
-    let module = lower_file_to_js_with_source(&file_ast, false, JsTarget::Cjs, None, Some(source_path), &semantic.name_resolution, &semantic.variant_calls);
->>>>>>> 3915757 (feat: add enum variant imports with use Enum::* syntax)
+    let module = lower_file_to_js_with_source(&file_ast, false, JsTarget::Cjs, None, Some(source_path), &semantic.name_resolution, &semantic.type_resolution, &semantic.variant_calls, &semantic.variant_patterns);
     let js_code = module.to_source_with_preamble();
 
     // Build test harness that runs each test

--- a/crates/husk-cli/src/main.rs
+++ b/crates/husk-cli/src/main.rs
@@ -503,7 +503,13 @@ fn run_compile(
     if source_map {
         // Generate with source map
         let source_path = Path::new(path);
+<<<<<<< HEAD
         let module = lower_file_to_js_with_source(&file, !lib, js_target, Some(&content), Some(source_path), &semantic.name_resolution, &semantic.type_resolution);
+||||||| parent of 3915757 (feat: add enum variant imports with use Enum::* syntax)
+        let module = lower_file_to_js_with_source(&file, !lib, js_target, Some(&content), Some(source_path), &semantic.name_resolution);
+=======
+        let module = lower_file_to_js_with_source(&file, !lib, js_target, Some(&content), Some(source_path), &semantic.name_resolution, &semantic.variant_calls);
+>>>>>>> 3915757 (feat: add enum variant imports with use Enum::* syntax)
         let source_file = Path::new(path)
             .file_name()
             .and_then(|s| s.to_str())
@@ -546,7 +552,13 @@ fn run_compile(
     } else {
         // Standard output (no source map)
         let source_path = Path::new(path);
+<<<<<<< HEAD
         let module = lower_file_to_js_with_source(&file, !lib, js_target, None, Some(source_path), &semantic.name_resolution, &semantic.type_resolution);
+||||||| parent of 3915757 (feat: add enum variant imports with use Enum::* syntax)
+        let module = lower_file_to_js_with_source(&file, !lib, js_target, None, Some(source_path), &semantic.name_resolution);
+=======
+        let module = lower_file_to_js_with_source(&file, !lib, js_target, None, Some(source_path), &semantic.name_resolution, &semantic.variant_calls);
+>>>>>>> 3915757 (feat: add enum variant imports with use Enum::* syntax)
         let js = module.to_source_with_preamble();
 
         if let Some(output_path) = output {
@@ -1059,7 +1071,12 @@ fn compile_to_file(path: &str, output: &str, target: Target, lib: bool, no_prelu
         Some(&content),
         Some(entry_path),
         &semantic.name_resolution,
+<<<<<<< HEAD
         &semantic.type_resolution,
+||||||| parent of 3915757 (feat: add enum variant imports with use Enum::* syntax)
+=======
+        &semantic.variant_calls,
+>>>>>>> 3915757 (feat: add enum variant imports with use Enum::* syntax)
     );
     let js = module.to_source_with_preamble();
 
@@ -1284,7 +1301,13 @@ fn run_build(
 
     if source_map {
         // Generate with source map
+<<<<<<< HEAD
         let module = lower_file_to_js_with_source(&filtered_ast, !lib, codegen_target, Some(&content), Some(&entry_path), &semantic.name_resolution, &semantic.type_resolution);
+||||||| parent of 3915757 (feat: add enum variant imports with use Enum::* syntax)
+        let module = lower_file_to_js_with_source(&filtered_ast, !lib, codegen_target, Some(&content), Some(&entry_path), &semantic.name_resolution);
+=======
+        let module = lower_file_to_js_with_source(&filtered_ast, !lib, codegen_target, Some(&content), Some(&entry_path), &semantic.name_resolution, &semantic.variant_calls);
+>>>>>>> 3915757 (feat: add enum variant imports with use Enum::* syntax)
         let source_file = entry_path
             .file_name()
             .and_then(|s| s.to_str())
@@ -1313,7 +1336,13 @@ fn run_build(
         }
     } else {
         // No source map
+<<<<<<< HEAD
         let module = lower_file_to_js(&filtered_ast, !lib, codegen_target, &semantic.name_resolution, &semantic.type_resolution);
+||||||| parent of 3915757 (feat: add enum variant imports with use Enum::* syntax)
+        let module = lower_file_to_js(&filtered_ast, !lib, codegen_target, &semantic.name_resolution);
+=======
+        let module = lower_file_to_js(&filtered_ast, !lib, codegen_target, &semantic.name_resolution, &semantic.variant_calls);
+>>>>>>> 3915757 (feat: add enum variant imports with use Enum::* syntax)
         let js = module.to_source_with_preamble();
 
         if let Err(err) = fs::write(&js_file, &js) {
@@ -1578,7 +1607,13 @@ fn run_test(
 
     // Compile to JS with lib mode (don't auto-call main)
     let source_path = Path::new(&path);
+<<<<<<< HEAD
     let module = lower_file_to_js_with_source(&file_ast, false, JsTarget::Cjs, None, Some(source_path), &semantic.name_resolution, &semantic.type_resolution);
+||||||| parent of 3915757 (feat: add enum variant imports with use Enum::* syntax)
+    let module = lower_file_to_js_with_source(&file_ast, false, JsTarget::Cjs, None, Some(source_path), &semantic.name_resolution);
+=======
+    let module = lower_file_to_js_with_source(&file_ast, false, JsTarget::Cjs, None, Some(source_path), &semantic.name_resolution, &semantic.variant_calls);
+>>>>>>> 3915757 (feat: add enum variant imports with use Enum::* syntax)
     let js_code = module.to_source_with_preamble();
 
     // Build test harness that runs each test

--- a/crates/husk-cli/tests/node_examples.rs
+++ b/crates/husk-cli/tests/node_examples.rs
@@ -86,7 +86,13 @@ fn examples_execute_with_node_when_available() {
         let filtered_file = filter_items_by_cfg(&file, &HashSet::new());
 
         // Lower to JS with preamble (bin mode: auto-call main when present).
+<<<<<<< HEAD
         let module = lower_file_to_js(&filtered_file, true, JsTarget::Cjs, &sem.name_resolution, &sem.type_resolution);
+||||||| parent of 3915757 (feat: add enum variant imports with use Enum::* syntax)
+        let module = lower_file_to_js(&filtered_file, true, JsTarget::Cjs, &sem.name_resolution);
+=======
+        let module = lower_file_to_js(&filtered_file, true, JsTarget::Cjs, &sem.name_resolution, &sem.variant_calls);
+>>>>>>> 3915757 (feat: add enum variant imports with use Enum::* syntax)
         let mut js = module.to_source_with_preamble();
 
         // For the minimal Express interop example, prepend a tiny stub `express`

--- a/crates/husk-cli/tests/node_examples.rs
+++ b/crates/husk-cli/tests/node_examples.rs
@@ -86,13 +86,7 @@ fn examples_execute_with_node_when_available() {
         let filtered_file = filter_items_by_cfg(&file, &HashSet::new());
 
         // Lower to JS with preamble (bin mode: auto-call main when present).
-<<<<<<< HEAD
-        let module = lower_file_to_js(&filtered_file, true, JsTarget::Cjs, &sem.name_resolution, &sem.type_resolution);
-||||||| parent of 3915757 (feat: add enum variant imports with use Enum::* syntax)
-        let module = lower_file_to_js(&filtered_file, true, JsTarget::Cjs, &sem.name_resolution);
-=======
-        let module = lower_file_to_js(&filtered_file, true, JsTarget::Cjs, &sem.name_resolution, &sem.variant_calls);
->>>>>>> 3915757 (feat: add enum variant imports with use Enum::* syntax)
+        let module = lower_file_to_js(&filtered_file, true, JsTarget::Cjs, &sem.name_resolution, &sem.type_resolution, &sem.variant_calls, &sem.variant_patterns);
         let mut js = module.to_source_with_preamble();
 
         // For the minimal Express interop example, prepend a tiny stub `express`

--- a/crates/husk-cli/tests/ts_interop.rs
+++ b/crates/husk-cli/tests/ts_interop.rs
@@ -53,13 +53,7 @@ fn typescript_can_typecheck_generated_dts_when_available() {
     fs::create_dir_all(&out_dir).expect("failed to create ts-interop directory");
 
     // Emit JS + preamble and .d.ts side by side.
-<<<<<<< HEAD
-    let module = lower_file_to_js(&file, false, JsTarget::Esm, &sem.name_resolution, &sem.type_resolution);
-||||||| parent of 3915757 (feat: add enum variant imports with use Enum::* syntax)
-    let module = lower_file_to_js(&file, false, JsTarget::Esm, &sem.name_resolution);
-=======
-    let module = lower_file_to_js(&file, false, JsTarget::Esm, &sem.name_resolution, &sem.variant_calls);
->>>>>>> 3915757 (feat: add enum variant imports with use Enum::* syntax)
+    let module = lower_file_to_js(&file, false, JsTarget::Esm, &sem.name_resolution, &sem.type_resolution, &sem.variant_calls, &sem.variant_patterns);
     let js = module.to_source_with_preamble();
     let js_path = out_dir.join("hello.js");
     fs::write(&js_path, js)

--- a/crates/husk-cli/tests/ts_interop.rs
+++ b/crates/husk-cli/tests/ts_interop.rs
@@ -53,7 +53,13 @@ fn typescript_can_typecheck_generated_dts_when_available() {
     fs::create_dir_all(&out_dir).expect("failed to create ts-interop directory");
 
     // Emit JS + preamble and .d.ts side by side.
+<<<<<<< HEAD
     let module = lower_file_to_js(&file, false, JsTarget::Esm, &sem.name_resolution, &sem.type_resolution);
+||||||| parent of 3915757 (feat: add enum variant imports with use Enum::* syntax)
+    let module = lower_file_to_js(&file, false, JsTarget::Esm, &sem.name_resolution);
+=======
+    let module = lower_file_to_js(&file, false, JsTarget::Esm, &sem.name_resolution, &sem.variant_calls);
+>>>>>>> 3915757 (feat: add enum variant imports with use Enum::* syntax)
     let js = module.to_source_with_preamble();
     let js_path = out_dir.join("hello.js");
     fs::write(&js_path, js)

--- a/stdlib/core.hk
+++ b/stdlib/core.hk
@@ -3,9 +3,6 @@
 // These definitions are written in Husk itself and are intended to serve
 // as the canonical Option/Result types for user code once a module system
 // and stdlib import mechanism are in place.
-//
-// For now they are validated by the compiler tests but are not yet
-// automatically imported into user programs.
 
 enum Option<T> {
     None,
@@ -16,6 +13,11 @@ enum Result<T, E> {
     Ok(T),
     Err(E),
 }
+
+// Import enum variants into scope so users can write Some(x), None, Ok(x), Err(e)
+// directly without the enum prefix.
+use Option::*;
+use Result::*;
 
 // ============================================================================
 // Conversion Traits


### PR DESCRIPTION
## Summary
- Implement Rust-style enum variant imports with three supported forms:
  - Glob imports: `use Option::*;`
  - Selective imports: `use Result::{Ok, Err};`
  - Single variant imports: `use Result::Ok;`
- Add `use Option::*;` and `use Result::*;` to the prelude so users can write `Some(x)`, `None`, `Ok(x)`, `Err(e)` directly

## Changes
- **AST**: Add `UseKind` enum to distinguish import types (Item, Glob, Variants)
- **Parser**: Handle `::*`, `::{A, B}`, and `::Variant` syntax in use statements
- **Semantic**: Track variant imports in `TypeEnv` and variant calls for codegen
- **Codegen**: Emit proper tagged union objects for imported variant calls
- **Prelude**: Add variant imports for Option and Result to stdlib/core.hk

## Test plan
- [x] All existing tests pass (50+ tests)
- [x] New variant import tests added in semantic analysis
- [x] End-to-end verification: `Some(42)` → `{tag: "Some", value: 42}`
- [x] Unit variant codegen: `None` → `{tag: "None"}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for glob and selective enum-variant imports (e.g., use Option::*, use Foo::{A, B})
  * Standard library variants (Some, None, Ok, Err) usable without enum prefixes

* **Improvements**
  * Variant-aware analysis and code generation so imported variants and match patterns emit correctly
  * Formatter renders suffixes for glob/selective imports
  * CLI/load refines import resolution, deduplicates externs/impls, and reports duplicate root imports as errors

* **Tests**
  * Added tests covering imported variants and lowering behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->