### PR TITLE
feat: add type inference with From/Into traits and turbofish syntax

### DIFF
--- a/crates/husk-ast/src/lib.rs
+++ b/crates/husk-ast/src/lib.rs
@@ -118,6 +118,9 @@ pub enum ExprKind {
     },
     Call {
         callee: Box<Expr>,
+        /// Turbofish type arguments: `foo::<i32, String>(x)`.
+        /// Empty if no explicit type arguments provided.
+        type_args: Vec<TypeExpr>,
         args: Vec<Expr>,
     },
     Field {
@@ -127,6 +130,9 @@ pub enum ExprKind {
     MethodCall {
         receiver: Box<Expr>,
         method: Ident,
+        /// Turbofish type arguments: `x.parse::<i32>()`.
+        /// Empty if no explicit type arguments provided.
+        type_args: Vec<TypeExpr>,
         args: Vec<Expr>,
     },
     Unary {

--- a/crates/husk-cli/src/main.rs
+++ b/crates/husk-cli/src/main.rs
@@ -503,7 +503,7 @@ fn run_compile(
     if source_map {
         // Generate with source map
         let source_path = Path::new(path);
-        let module = lower_file_to_js_with_source(&file, !lib, js_target, Some(&content), Some(source_path), &semantic.name_resolution);
+        let module = lower_file_to_js_with_source(&file, !lib, js_target, Some(&content), Some(source_path), &semantic.name_resolution, &semantic.type_resolution);
         let source_file = Path::new(path)
             .file_name()
             .and_then(|s| s.to_str())
@@ -546,7 +546,7 @@ fn run_compile(
     } else {
         // Standard output (no source map)
         let source_path = Path::new(path);
-        let module = lower_file_to_js_with_source(&file, !lib, js_target, None, Some(source_path), &semantic.name_resolution);
+        let module = lower_file_to_js_with_source(&file, !lib, js_target, None, Some(source_path), &semantic.name_resolution, &semantic.type_resolution);
         let js = module.to_source_with_preamble();
 
         if let Some(output_path) = output {
@@ -1059,6 +1059,7 @@ fn compile_to_file(path: &str, output: &str, target: Target, lib: bool, no_prelu
         Some(&content),
         Some(entry_path),
         &semantic.name_resolution,
+        &semantic.type_resolution,
     );
     let js = module.to_source_with_preamble();
 
@@ -1283,7 +1284,7 @@ fn run_build(
 
     if source_map {
         // Generate with source map
-        let module = lower_file_to_js_with_source(&filtered_ast, !lib, codegen_target, Some(&content), Some(&entry_path), &semantic.name_resolution);
+        let module = lower_file_to_js_with_source(&filtered_ast, !lib, codegen_target, Some(&content), Some(&entry_path), &semantic.name_resolution, &semantic.type_resolution);
         let source_file = entry_path
             .file_name()
             .and_then(|s| s.to_str())
@@ -1312,7 +1313,7 @@ fn run_build(
         }
     } else {
         // No source map
-        let module = lower_file_to_js(&filtered_ast, !lib, codegen_target, &semantic.name_resolution);
+        let module = lower_file_to_js(&filtered_ast, !lib, codegen_target, &semantic.name_resolution, &semantic.type_resolution);
         let js = module.to_source_with_preamble();
 
         if let Err(err) = fs::write(&js_file, &js) {
@@ -1577,7 +1578,7 @@ fn run_test(
 
     // Compile to JS with lib mode (don't auto-call main)
     let source_path = Path::new(&path);
-    let module = lower_file_to_js_with_source(&file_ast, false, JsTarget::Cjs, None, Some(source_path), &semantic.name_resolution);
+    let module = lower_file_to_js_with_source(&file_ast, false, JsTarget::Cjs, None, Some(source_path), &semantic.name_resolution, &semantic.type_resolution);
     let js_code = module.to_source_with_preamble();
 
     // Build test harness that runs each test

--- a/crates/husk-cli/tests/node_examples.rs
+++ b/crates/husk-cli/tests/node_examples.rs
@@ -86,7 +86,7 @@ fn examples_execute_with_node_when_available() {
         let filtered_file = filter_items_by_cfg(&file, &HashSet::new());
 
         // Lower to JS with preamble (bin mode: auto-call main when present).
-        let module = lower_file_to_js(&filtered_file, true, JsTarget::Cjs, &sem.name_resolution);
+        let module = lower_file_to_js(&filtered_file, true, JsTarget::Cjs, &sem.name_resolution, &sem.type_resolution);
         let mut js = module.to_source_with_preamble();
 
         // For the minimal Express interop example, prepend a tiny stub `express`

--- a/crates/husk-cli/tests/ts_interop.rs
+++ b/crates/husk-cli/tests/ts_interop.rs
@@ -53,7 +53,7 @@ fn typescript_can_typecheck_generated_dts_when_available() {
     fs::create_dir_all(&out_dir).expect("failed to create ts-interop directory");
 
     // Emit JS + preamble and .d.ts side by side.
-    let module = lower_file_to_js(&file, false, JsTarget::Esm, &sem.name_resolution);
+    let module = lower_file_to_js(&file, false, JsTarget::Esm, &sem.name_resolution, &sem.type_resolution);
     let js = module.to_source_with_preamble();
     let js_path = out_dir.join("hello.js");
     fs::write(&js_path, js)

--- a/crates/husk-fmt/src/visitor.rs
+++ b/crates/husk-fmt/src/visitor.rs
@@ -1102,8 +1102,18 @@ impl<'a> Formatter<'a> {
                     self.write(&segment.name);
                 }
             }
-            ExprKind::Call { callee, args } => {
+            ExprKind::Call { callee, type_args, args } => {
                 self.format_expr(callee);
+                if !type_args.is_empty() {
+                    self.write("::<");
+                    for (i, ty) in type_args.iter().enumerate() {
+                        if i > 0 {
+                            self.write(", ");
+                        }
+                        self.format_type(ty);
+                    }
+                    self.write(">");
+                }
                 self.write("(");
                 for (i, arg) in args.iter().enumerate() {
                     if i > 0 {
@@ -1121,11 +1131,22 @@ impl<'a> Formatter<'a> {
             ExprKind::MethodCall {
                 receiver,
                 method,
+                type_args,
                 args,
             } => {
                 self.format_expr(receiver);
                 self.write(".");
                 self.write(&method.name);
+                if !type_args.is_empty() {
+                    self.write("::<");
+                    for (i, ty) in type_args.iter().enumerate() {
+                        if i > 0 {
+                            self.write(", ");
+                        }
+                        self.format_type(ty);
+                    }
+                    self.write(">");
+                }
                 self.write("(");
                 for (i, arg) in args.iter().enumerate() {
                     if i > 0 {

--- a/crates/husk-runtime-js/src/lib.rs
+++ b/crates/husk-runtime-js/src/lib.rs
@@ -23,7 +23,7 @@ function Ok(value) {
 }
 
 function Err(error) {
-    return { tag: "Err", error };
+    return { tag: "Err", value: error };
 }
 
 function panic(message) {
@@ -434,6 +434,54 @@ function __husk_expect(value, message) {
     }
     // Not a Result/Option, return as-is
     return value;
+}
+
+// Parse string to i32, returns Result<i32, String>
+function __husk_parse_i32(str) {
+    var n = parseInt(str, 10);
+    if (isNaN(n)) {
+        return { tag: "Err", value: "invalid digit found in string" };
+    }
+    if (n < -2147483648 || n > 2147483647) {
+        return { tag: "Err", value: "number too large or too small for i32" };
+    }
+    return { tag: "Ok", value: n };
+}
+
+// Parse string to i64, returns Result<i64, String>
+function __husk_parse_i64(str) {
+    try {
+        var n = BigInt(str);
+        return { tag: "Ok", value: n };
+    } catch (e) {
+        return { tag: "Err", value: "invalid digit found in string" };
+    }
+}
+
+// Parse string to f64, returns Result<f64, String>
+function __husk_parse_f64(str) {
+    var n = parseFloat(str);
+    if (isNaN(n) && str.trim() !== "NaN") {
+        return { tag: "Err", value: "invalid float literal" };
+    }
+    return { tag: "Ok", value: n };
+}
+
+// Try to convert i64 to i32, returns Result<i32, String>
+function __husk_try_into_i32(value) {
+    var n;
+    if (typeof value === "bigint") {
+        if (value < -2147483648n || value > 2147483647n) {
+            return { tag: "Err", value: "out of range integral type conversion" };
+        }
+        n = Number(value);
+    } else {
+        n = value;
+        if (n < -2147483648 || n > 2147483647) {
+            return { tag: "Err", value: "out of range integral type conversion" };
+        }
+    }
+    return { tag: "Ok", value: n | 0 };
 }
 "#
 }

--- a/crates/husk-runtime-js/src/lib.rs
+++ b/crates/husk-runtime-js/src/lib.rs
@@ -82,9 +82,6 @@ function __husk_fmt_debug(value, pretty) {
             if (keys.length === 1 && keys[0] === "value") {
                 return tag + "(" + __husk_fmt_debug(value.value, pretty) + ")";
             }
-            if (keys.length === 1 && keys[0] === "error") {
-                return tag + "(" + __husk_fmt_debug(value.error, pretty) + ")";
-            }
             // General struct fields
             var fields = keys.map(function(k) { return k + ": " + __husk_fmt_debug(value[k], pretty); });
             if (pretty) return tag + " {\n  " + fields.join(",\n  ") + "\n}";
@@ -400,7 +397,7 @@ function __husk_unwrap(value) {
             return value.value;
         }
         if (value.tag === "Err") {
-            throw new Error("[Husk panic] called unwrap on Err: " + __husk_fmt_debug(value.error));
+            throw new Error("[Husk panic] called unwrap on Err: " + __husk_fmt_debug(value.value));
         }
         if (value.tag === "Some") {
             return value.value;
@@ -423,7 +420,7 @@ function __husk_expect(value, message) {
             return value.value;
         }
         if (value.tag === "Err") {
-            throw new Error("[Husk panic] " + message + ": " + __husk_fmt_debug(value.error));
+            throw new Error("[Husk panic] " + message + ": " + __husk_fmt_debug(value.value));
         }
         if (value.tag === "Some") {
             return value.value;

--- a/examples/type_inference.hk
+++ b/examples/type_inference.hk
@@ -1,0 +1,44 @@
+// Type inference examples demonstrating From/Into traits and turbofish syntax
+
+fn main() {
+    // Test .into() with type annotation (type inferred from context)
+    let s: String = 42.into();
+    println("i32 to String: {}", s);
+
+    // Test .into() with turbofish (explicit type)
+    let s2 = 123.into::<String>();
+    println("i32 to String (turbofish): {}", s2);
+
+    // Test .parse() with turbofish
+    let n = "456".parse::<i32>();
+    match n {
+        Result::Ok(value) => println("Parsed i32: {}", value),
+        Result::Err(e) => println("Parse error: {}", e),
+    }
+
+    // Test .parse() for f64
+    let f = "3.14159".parse::<f64>();
+    match f {
+        Result::Ok(value) => println("Parsed f64: {}", value),
+        Result::Err(e) => println("Parse error: {}", e),
+    }
+
+    // Test i32 to i64 widening conversion
+    let i: i64 = 100.into();
+    println("i32 to i64: {}", i);
+
+    // Test i32 to f64 widening conversion
+    let d: f64 = 50.into();
+    println("i32 to f64: {}", d);
+
+    // Test bool to String conversion
+    let b: String = true.into();
+    println("bool to String: {}", b);
+
+    // Test parse error case
+    let bad = "not_a_number".parse::<i32>();
+    match bad {
+        Result::Ok(v) => println("Unexpectedly got: {}", v),
+        Result::Err(e) => println("Expected error: {}", e),
+    }
+}

--- a/stdlib/core.hk
+++ b/stdlib/core.hk
@@ -18,6 +18,144 @@ enum Result<T, E> {
 }
 
 // ============================================================================
+// Conversion Traits
+// ============================================================================
+
+// Trait for infallible type conversions.
+//
+// Used to convert a value from one type to another. If `From<T>` is
+// implemented for `U`, then `T` can be converted to `U` using `U::from(value)`
+// or `value.into()` (via the blanket impl of `Into`).
+//
+// Example:
+//   let s: String = String::from(42);   // explicit From
+//   let s: String = 42.into();          // using Into (requires type annotation)
+trait From<T> {
+    fn from(value: T) -> Self;
+}
+
+// Trait for infallible type conversions (consuming self).
+//
+// This is the reciprocal of `From<T>`. Calling `.into()` on a value converts
+// it to the target type. The target type must be inferrable from context
+// (type annotation, return type, etc.) or specified with turbofish syntax.
+//
+// Note: The compiler provides a blanket impl: if `U: From<T>`, then `T: Into<U>`.
+// You should generally implement `From` rather than `Into` directly.
+trait Into<T> {
+    fn into(self) -> T;
+}
+
+// Trait for fallible type conversions.
+//
+// Used when a conversion might fail. Returns `Result<Self, Self::Error>`.
+//
+// Example:
+//   let n: Result<i32, String> = i32::try_from("123");
+//   let n: Result<i32, String> = "123".try_into();
+trait TryFrom<T> {
+    // Note: Associated types are not yet fully supported, so we use String
+    // as the default error type for now.
+    fn try_from(value: T) -> Result<Self, String>;
+}
+
+// Trait for fallible type conversions (consuming self).
+//
+// This is the reciprocal of `TryFrom<T>`.
+trait TryInto<T> {
+    fn try_into(self) -> Result<T, String>;
+}
+
+// ============================================================================
+// Standard From/Into Implementations
+// ============================================================================
+
+// String conversions (infallible)
+impl From<i32> for String {
+    fn from(value: i32) -> String {
+        // Implemented by codegen as String(value) in JS
+        value.toString()
+    }
+}
+
+impl From<i64> for String {
+    fn from(value: i64) -> String {
+        value.toString()
+    }
+}
+
+impl From<f64> for String {
+    fn from(value: f64) -> String {
+        value.toString()
+    }
+}
+
+impl From<bool> for String {
+    fn from(value: bool) -> String {
+        value.toString()
+    }
+}
+
+// Numeric widening conversions (infallible)
+impl From<i32> for i64 {
+    fn from(value: i32) -> i64 {
+        value as i64
+    }
+}
+
+impl From<i32> for f64 {
+    fn from(value: i32) -> f64 {
+        value as f64
+    }
+}
+
+impl From<i64> for f64 {
+    fn from(value: i64) -> f64 {
+        value as f64
+    }
+}
+
+// ============================================================================
+// Standard TryFrom/TryInto Implementations
+// ============================================================================
+
+// Parse string to i32
+impl TryFrom<String> for i32 {
+    fn try_from(value: String) -> Result<i32, String> {
+        // Implemented by codegen as parseInt with error handling
+        let n = parseInt(value);
+        // Note: parseInt returns NaN for invalid input
+        // This will be handled in codegen with proper JS NaN check
+        Result::Ok(n)
+    }
+}
+
+// Parse string to i64
+impl TryFrom<String> for i64 {
+    fn try_from(value: String) -> Result<i64, String> {
+        let n = parseLong(value);
+        Result::Ok(n)
+    }
+}
+
+// Parse string to f64
+impl TryFrom<String> for f64 {
+    fn try_from(value: String) -> Result<f64, String> {
+        let n = parseFloat(value);
+        Result::Ok(n)
+    }
+}
+
+// Narrowing conversion (may overflow)
+impl TryFrom<i64> for i32 {
+    fn try_from(value: i64) -> Result<i32, String> {
+        // Check if value fits in i32 range
+        // Implemented by codegen with proper bounds check
+        Result::Ok(value as i32)
+    }
+}
+
+// ============================================================================
 // Comparison Traits
 // ============================================================================
 

--- a/stdlib/core.hk
+++ b/stdlib/core.hk
@@ -71,9 +71,10 @@ trait TryInto<T> {
 // ============================================================================
 
 // String conversions (infallible)
+// NOTE: These are trait definitions for semantic analysis.
+// Codegen replaces .into() calls with String(value) in JS.
 impl From<i32> for String {
     fn from(value: i32) -> String {
-        // Implemented by codegen as String(value) in JS
         value.toString()
     }
 }
@@ -147,10 +148,13 @@ impl TryFrom<String> for f64 {
 }
 
 // Narrowing conversion (may overflow)
+// NOTE: This is a trait definition for semantic analysis only.
+// The actual implementation with bounds checking is in the JS runtime
+// (__husk_try_into_i32), which codegen calls instead of this body.
 impl TryFrom<i64> for i32 {
     fn try_from(value: i64) -> Result<i32, String> {
-        // Check if value fits in i32 range
-        // Implemented by codegen with proper bounds check
+        // Placeholder body - codegen replaces with __husk_try_into_i32(value)
+        // which performs: value < -2147483648 || value > 2147483647 check
         Result::Ok(value as i32)
     }
 }

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -43,7 +43,7 @@ fn examples_codegen() {
         };
         let sem = analyze_file(&file);
         if sem.symbols.errors.is_empty() && sem.type_errors.is_empty() {
-            let module = lower_file_to_js(&file, true, JsTarget::Cjs);
+            let module = lower_file_to_js(&file, true, JsTarget::Cjs, &sem.name_resolution, &sem.type_resolution);
             let _js = module.to_source_with_preamble();
         }
     }


### PR DESCRIPTION
## Summary

- Add Rust-like type inference for type conversions using From/Into traits
- Implement turbofish syntax (`::<Type>`) for explicit type specification
- Enable `.into()` and `.parse()` methods with bidirectional type inference
- Add comprehensive test suite for type inference scenarios

## Features

**Type Conversion Traits:**
- `From<T>` / `Into<T>` for infallible conversions
- `TryFrom<T>` / `TryInto<T>` for fallible conversions (returns `Result<T, String>`)

**Supported Conversions:**
- `i32`, `i64`, `f64`, `bool` → `String`
- `i32` → `i64`, `f64` (widening)
- `i64` → `f64` (widening)
- String parsing via `.parse::<T>()` for `i32`, `i64`, `f64`

**Type Inference Contexts:**
- Variable annotations: `let s: String = 42.into();`
- Turbofish syntax: `let s = 42.into::<String>();`
- Function arguments: `takes_string(42.into());`
- Return position: `fn to_string() -> String { 42.into() }`

## Example

```rust
fn main() {
    // Type inferred from annotation
    let s: String = 42.into();
    
    // Explicit turbofish syntax
    let s2 = 123.into::<String>();
    
    // Parse with turbofish
    let n = "456".parse::<i32>();
    match n {
        Result::Ok(value) => println("Parsed: {}", value),
        Result::Err(e) => println("Error: {}", e),
    }
    
    // Widening conversions
    let i: i64 = 100.into();
    let d: f64 = 50.into();
}
```

## Test plan

- [x] All existing tests pass
- [x] New semantic tests for type inference (18 tests)
- [x] Example file `examples/type_inference.hk` runs correctly
- [x] Node examples integration tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for turbofish generic arguments on calls and methods (e.g., value.parse::<T>())
  * New conversion traits and implementations: From/Into and TryFrom/TryInto with built-in conversions and parsing helpers
  * Codegen now preserves and uses resolved target types to emit appropriate JS conversions
  * Formatter now prints turbofish type args when present

* **Bug Fixes**
  * Unwrap/expect error messages adjusted to reference the returned value variant

* **Documentation**
  * Added example demonstrating conversions, turbofish, and parse behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->