### PR TITLE
feat: add tuple support following Rust semantics

### DIFF
--- a/crates/husk-ast/src/lib.rs
+++ b/crates/husk-ast/src/lib.rs
@@ -211,6 +211,13 @@ pub enum ExprKind {
         expr: Box<Expr>,
         target_ty: TypeExpr,
     },
+    /// Tuple literal expression: `(1, "hello", true)` or `(a, b)`
+    Tuple { elements: Vec<Expr> },
+    /// Tuple field access: `tuple.0`, `tuple.1`, etc.
+    TupleField {
+        base: Box<Expr>,
+        index: usize,
+    },
 }
 
 // ============================================================================
@@ -320,6 +327,10 @@ pub enum PatternKind {
         path: Vec<Ident>,
         fields: Vec<(Ident, Pattern)>,
     },
+    /// Tuple pattern: `(x, y, z)` for destructuring tuples
+    Tuple {
+        fields: Vec<Pattern>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -340,7 +351,7 @@ pub struct MatchArm {
 pub enum StmtKind {
     Let {
         mutable: bool,
-        name: Ident,
+        pattern: Pattern,
         ty: Option<TypeExpr>,
         value: Option<Expr>,
     },
@@ -395,6 +406,8 @@ pub enum TypeExprKind {
     Function { params: Vec<TypeExpr>, ret: Box<TypeExpr> },
     /// Array type: `[ElementType]`
     Array(Box<TypeExpr>),
+    /// Tuple type: `(T1, T2, T3)`
+    Tuple(Vec<TypeExpr>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/husk-cli/src/load.rs
+++ b/crates/husk-cli/src/load.rs
@@ -410,6 +410,10 @@ fn type_expr_to_name(ty: &TypeExpr) -> String {
         TypeExprKind::Generic { name, .. } => name.name.clone(),
         TypeExprKind::Function { .. } => String::new(),
         TypeExprKind::Array(elem) => format!("[{}]", type_expr_to_name(elem)),
+        TypeExprKind::Tuple(types) => {
+            let type_names: Vec<String> = types.iter().map(type_expr_to_name).collect();
+            format!("({})", type_names.join(", "))
+        }
     }
 }
 

--- a/crates/husk-cli/tests/method_renaming.rs
+++ b/crates/husk-cli/tests/method_renaming.rs
@@ -57,6 +57,8 @@ fn main() {
         JsTarget::Cjs,
         &sem.name_resolution,
         &sem.type_resolution,
+        &sem.variant_calls,
+        &sem.variant_patterns,
     );
     let js = module.to_source();
 
@@ -133,6 +135,8 @@ fn main() {
         JsTarget::Cjs,
         &sem.name_resolution,
         &sem.type_resolution,
+        &sem.variant_calls,
+        &sem.variant_patterns,
     );
     let js = module.to_source();
 

--- a/crates/husk-cli/tests/module_loader.rs
+++ b/crates/husk-cli/tests/module_loader.rs
@@ -13,6 +13,10 @@ fn type_expr_to_name(ty: &husk_ast::TypeExpr) -> String {
         TypeExprKind::Generic { name, .. } => name.name.clone(),
         TypeExprKind::Function { .. } => String::new(),
         TypeExprKind::Array(elem) => format!("[{}]", type_expr_to_name(elem)),
+        TypeExprKind::Tuple(types) => {
+            let type_names: Vec<String> = types.iter().map(type_expr_to_name).collect();
+            format!("({})", type_names.join(", "))
+        }
     }
 }
 

--- a/crates/husk-fmt/src/visitor.rs
+++ b/crates/husk-fmt/src/visitor.rs
@@ -895,6 +895,20 @@ impl<'a> Formatter<'a> {
                 self.format_type(elem);
                 self.write("]");
             }
+            TypeExprKind::Tuple(types) => {
+                self.write("(");
+                for (i, ty) in types.iter().enumerate() {
+                    if i > 0 {
+                        self.write(", ");
+                    }
+                    self.format_type(ty);
+                }
+                // Single-element tuple needs trailing comma
+                if types.len() == 1 {
+                    self.write(",");
+                }
+                self.write(")");
+            }
         }
     }
 
@@ -911,7 +925,7 @@ impl<'a> Formatter<'a> {
         match &stmt.kind {
             StmtKind::Let {
                 mutable,
-                name,
+                pattern,
                 ty,
                 value,
             } => {
@@ -920,7 +934,7 @@ impl<'a> Formatter<'a> {
                 if *mutable {
                     self.write("mut ");
                 }
-                self.write(&name.name);
+                self.format_pattern(pattern);
                 if let Some(ty) = ty {
                     self.write(": ");
                     self.format_type(ty);
@@ -1369,6 +1383,25 @@ impl<'a> Formatter<'a> {
                 self.write(" as ");
                 self.format_type(target_ty);
             }
+            ExprKind::Tuple { elements } => {
+                self.write("(");
+                for (i, elem) in elements.iter().enumerate() {
+                    if i > 0 {
+                        self.write(", ");
+                    }
+                    self.format_expr(elem);
+                }
+                // Single-element tuple needs trailing comma
+                if elements.len() == 1 {
+                    self.write(",");
+                }
+                self.write(")");
+            }
+            ExprKind::TupleField { base, index } => {
+                self.format_expr(base);
+                self.write(".");
+                self.write(&index.to_string());
+            }
         }
     }
 
@@ -1485,6 +1518,20 @@ impl<'a> Formatter<'a> {
                     self.format_pattern(pattern);
                 }
                 self.write(" }");
+            }
+            PatternKind::Tuple { fields } => {
+                self.write("(");
+                for (i, field) in fields.iter().enumerate() {
+                    if i > 0 {
+                        self.write(", ");
+                    }
+                    self.format_pattern(field);
+                }
+                // Single-element tuple needs trailing comma
+                if fields.len() == 1 {
+                    self.write(",");
+                }
+                self.write(")");
             }
         }
     }

--- a/crates/husk-semantic/src/lib.rs
+++ b/crates/husk-semantic/src/lib.rs
@@ -563,6 +563,9 @@ fn substitute_type_param(ty: &Type, param: &str, replacement: &Type) -> Type {
                 ret: Box::new(substitute_type_param(ret, param, replacement)),
             }
         }
+        Type::Tuple(elements) => {
+            Type::Tuple(elements.iter().map(|e| substitute_type_param(e, param, replacement)).collect())
+        }
         Type::Primitive(_) | Type::Var(_) => ty.clone(),
     }
 }

--- a/crates/husk-types/src/lib.rs
+++ b/crates/husk-types/src/lib.rs
@@ -122,4 +122,18 @@ mod tests {
             _ => panic!("expected function type"),
         }
     }
+
+    #[test]
+    fn tuple_type() {
+        let t = Type::tuple(vec![Type::i32(), Type::string(), Type::bool()]);
+        match t {
+            Type::Tuple(elements) => {
+                assert_eq!(elements.len(), 3);
+                assert_eq!(elements[0], Type::i32());
+                assert_eq!(elements[1], Type::string());
+                assert_eq!(elements[2], Type::bool());
+            }
+            _ => panic!("expected tuple type"),
+        }
+    }
 }

--- a/crates/husk-types/src/lib.rs
+++ b/crates/husk-types/src/lib.rs
@@ -35,6 +35,8 @@ pub enum Type {
     Var(TypeVarId),
     /// An array type: `[T]`.
     Array(Box<Type>),
+    /// A tuple type: `(T1, T2, ...)`.
+    Tuple(Vec<Type>),
 }
 
 impl Type {
@@ -74,6 +76,10 @@ impl Type {
             params,
             ret: Box::new(ret),
         }
+    }
+
+    pub fn tuple(elements: Vec<Type>) -> Self {
+        Type::Tuple(elements)
     }
 }
 

--- a/examples/feature_tuples/basic_tuples.hk
+++ b/examples/feature_tuples/basic_tuples.hk
@@ -25,6 +25,13 @@ fn main() {
     // Multiple element tuple
     let triple: (i32, bool, String) = (1, true, "test");
     let (n, flag, text) = triple;
+
+    // Single-element tuple (requires trailing comma)
+    let single: (i32,) = (100,);
+    let single_val = single.0;
+
+    // Wildcard in tuple pattern
+    let (a, _) = pair;
 }
 
 fn create_pair(num: i32, text: String) -> (i32, String) {

--- a/examples/feature_tuples/basic_tuples.hk
+++ b/examples/feature_tuples/basic_tuples.hk
@@ -1,0 +1,32 @@
+// Test basic tuple functionality
+
+fn main() {
+    // Create a simple tuple
+    let pair: (i32, String) = (42, "hello");
+
+    // Access tuple fields
+    let first = pair.0;
+    let second = pair.1;
+
+    // Destructure a tuple
+    let (x, y) = pair;
+
+    // Nested tuples
+    let nested: ((i32, i32), String) = ((1, 2), "point");
+    let nested_first = nested.0.0;
+    let nested_second = nested.0.1;
+    let nested_label = nested.1;
+
+    // Tuple in function return
+    let result = create_pair(10, "world");
+    let r0 = result.0;
+    let r1 = result.1;
+
+    // Multiple element tuple
+    let triple: (i32, bool, String) = (1, true, "test");
+    let (n, flag, text) = triple;
+}
+
+fn create_pair(num: i32, text: String) -> (i32, String) {
+    (num, text)
+}

--- a/examples/feature_tuples/nested_destructure.hk
+++ b/examples/feature_tuples/nested_destructure.hk
@@ -1,0 +1,19 @@
+// Test nested tuple destructuring
+
+fn main() {
+    // Nested tuple destructuring
+    let nested: ((i32, i32), String) = ((1, 2), "point");
+    let ((a, b), label) = nested;
+
+    // Use the destructured values to prove they exist
+    let sum = a + b;
+
+    // Deeper nesting
+    let deep: (((i32, i32), i32), String) = (((10, 20), 30), "deep");
+    let (((x, y), z), name) = deep;
+
+    let total = x + y + z;
+
+    // Just use the values
+    let check = sum + total;
+}


### PR DESCRIPTION
## Summary

- Add comprehensive tuple support to Husk following Rust's tuple semantics
- Tuples compile to JavaScript arrays with proper type annotations
- Support tuple destructuring in let statements and match expressions

### Features Added

- **Tuple types**: `(T1, T2, T3)` - fully parsed and type-checked
- **Tuple literals**: `(1, "hello", true)` - compile to JavaScript arrays
- **Tuple field access**: `tuple.0`, `tuple.1` - generates array indexing
- **Chained tuple access**: `nested.0.0` - correctly handles the lexer edge case where `0.0` is parsed as a float literal
- **Tuple destructuring**: `let (x, y) = pair;` - uses JavaScript array destructuring
- **Tuple patterns** in match expressions
- **Function return tuples**: `fn foo() -> (i32, String)`

### Implementation

Changes span all major crates:
- `husk-types`: Added `Type::Tuple(Vec<Type>)` variant
- `husk-ast`: Added `TypeExprKind::Tuple`, `ExprKind::Tuple`, `ExprKind::TupleField`, `PatternKind::Tuple`, and updated `StmtKind::Let` to use patterns
- `husk-parser`: Parse tuple types, literals, field access, and patterns
- `husk-semantic`: Type checking for all tuple operations
- `husk-codegen-js`: Generate JavaScript arrays with destructuring support
- `husk-fmt`: Format tuple types, expressions, and patterns

### Example

```rust
fn main() {
    let pair: (i32, String) = (42, "hello");
    let first = pair.0;
    let (x, y) = pair;
    
    let nested: ((i32, i32), String) = ((1, 2), "point");
    let inner = nested.0.0; // Chained access works!
}
```

Compiles to:
```javascript
function main() {
    let pair = [42, "hello"];
    let first = pair[0];
    let [x, y] = pair;
    
    let nested = [[1, 2], "point"];
    let inner = nested[0][0];
}
```

## Test plan

- [x] All cargo tests pass
- [x] Basic tuple test file compiles and runs successfully
- [x] Tuple field access generates correct JavaScript indexing
- [x] Chained tuple access (`nested.0.0`) works correctly
- [x] Tuple destructuring in let statements generates JS array destructuring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full tuple support across language, compiler, and JS output: tuple literals (including single-element trailing-comma), nested tuples, tuple types, tuple field access (e.g., .0), wildcard patterns, and destructuring in let-bindings and matches. JS/TS emission now preserves tuple shapes and emits destructuring.

* **Formatting**
  * Formatter consistently handles tuple syntax and trailing-comma rules.

* **Examples / Tests**
  * Added examples and comprehensive tests covering parsing, typing, access, destructuring, and printing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->