### PR TITLE
feat(lsp): enhance hover to show type info and doc comments

### DIFF
--- a/crates/husk-lexer/src/lib.rs
+++ b/crates/husk-lexer/src/lib.rs
@@ -28,6 +28,20 @@ impl Trivia {
     pub fn is_comment(&self) -> bool {
         matches!(self, Trivia::LineComment(_))
     }
+
+    /// Returns true if this trivia is a documentation comment (starts with `/// `).
+    pub fn is_doc_comment(&self) -> bool {
+        matches!(self, Trivia::LineComment(s) if s.starts_with("/// "))
+    }
+
+    /// Extract doc content from a doc comment, removing the `/// ` prefix.
+    /// Returns None if this is not a doc comment.
+    pub fn doc_content(&self) -> Option<&str> {
+        match self {
+            Trivia::LineComment(s) if s.starts_with("/// ") => Some(&s[4..]),
+            _ => None,
+        }
+    }
 }
 
 /// List of all Husk keywords.

--- a/crates/husk-lsp/src/document.rs
+++ b/crates/husk-lsp/src/document.rs
@@ -80,6 +80,12 @@ impl Document {
 
     /// Get the word at a given byte offset.
     pub fn word_at_offset(&self, offset: usize) -> Option<String> {
+        self.word_span_at_offset(offset).map(|(word, _, _)| word)
+    }
+
+    /// Get the word and its span at a given byte offset.
+    /// Returns (word, start_offset, end_offset) if found.
+    pub fn word_span_at_offset(&self, offset: usize) -> Option<(String, usize, usize)> {
         if offset >= self.text.len() {
             return None;
         }
@@ -107,7 +113,7 @@ impl Document {
             return None;
         }
 
-        Some(self.text[start..end].to_string())
+        Some((self.text[start..end].to_string(), start, end))
     }
 }
 

--- a/crates/husk-parser/src/lib.rs
+++ b/crates/husk-parser/src/lib.rs
@@ -42,6 +42,8 @@ enum JsParseState {
 pub struct ParseResult {
     pub file: Option<File>,
     pub errors: Vec<ParseError>,
+    /// The tokens from lexing, useful for accessing trivia (comments).
+    pub tokens: Vec<Token>,
 }
 
 /// Parse a source string into an AST `File` and a list of parse errors.
@@ -49,11 +51,12 @@ pub fn parse_str(source: &str) -> ParseResult {
     debug_log("[huskc-parser] lexing");
     let tokens: Vec<Token> = Lexer::new(source).collect();
     debug_log(&format!("[huskc-parser] lexed {} tokens", tokens.len()));
-    let mut parser = Parser::new(tokens, source);
+    let mut parser = Parser::new(tokens.clone(), source);
     let file = parser.parse_file();
     ParseResult {
         file: Some(file),
         errors: parser.errors,
+        tokens,
     }
 }
 


### PR DESCRIPTION
## Summary

Enhance LSP hover functionality to show type information and doc comments (rust-analyzer style) instead of just variable names.

- Display type information for variables, function parameters, and field accesses
- Show full signatures for functions, structs, and enums
- Include doc comments (`///` style) when available
- Format output in rust-analyzer style with code blocks and separators

### Example hover output

**Variable:**
```husk
total: i64
```

**Function:**
```husk
fn add(a: i32, b: i32) -> i32
```
---
Calculates the sum of two numbers.

**Field access:**
```husk
Point.x: i32
```

## Files changed

| File | Changes |
|------|---------|
| `crates/husk-semantic/src/lib.rs` | Add `HoverInfo`, `HoverMap`; extend `TypeChecker` to record hover info during type checking |
| `crates/husk-lsp/src/backend.rs` | Rewrite `hover()` with semantic analysis, doc map building, markdown formatting |
| `crates/husk-lsp/src/document.rs` | Add `word_span_at_offset()` helper |
| `crates/husk-lexer/src/lib.rs` | Add `is_doc_comment()` and `doc_content()` methods to `Trivia` |
| `crates/husk-parser/src/lib.rs` | Expose `tokens` in `ParseResult` for doc comment extraction |

## Test plan

- [x] All existing tests pass
- [ ] Manual testing with LSP in editor (hover over variables, functions, structs, enums, field accesses)
- [ ] Verify doc comments appear in hover for documented items

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced hover tooltips with detailed type signatures and documentation
  * Improved code element information display for functions, structs, enums, and variables
  * Better inline documentation visibility in the language server

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->