### PR TITLE
feat: add if-let and let-else syntax support

### DIFF
--- a/crates/husk-ast/src/lib.rs
+++ b/crates/husk-ast/src/lib.rs
@@ -354,6 +354,7 @@ pub enum StmtKind {
         pattern: Pattern,
         ty: Option<TypeExpr>,
         value: Option<Expr>,
+        else_block: Option<Block>, // for let...else syntax
     },
     /// Assignment statement: `target = value` or `target += value` etc.
     Assign {
@@ -389,6 +390,13 @@ pub enum StmtKind {
     Break,
     Continue,
     Block(Block),
+    /// if let pattern = expr { then } [else { else }]
+    IfLet {
+        pattern: Pattern,
+        scrutinee: Expr,
+        then_branch: Block,
+        else_branch: Option<Box<Stmt>>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/husk-codegen-js/src/lib.rs
+++ b/crates/husk-codegen-js/src/lib.rs
@@ -1512,14 +1512,12 @@ fn extract_refutable_pattern_bindings(
                     return vec![(ctx.resolve_name(&ident.name, &ident.span), accessor)];
                 }
             } else {
+                // Multiple fields: access via ["0"], ["1"], etc. (no .value wrapper)
                 let mut bindings = Vec::new();
                 for (i, field) in fields.iter().enumerate() {
                     if let PatternKind::Binding(ident) = &field.kind {
                         let accessor = JsExpr::Index {
-                            object: Box::new(JsExpr::Member {
-                                object: Box::new(scrutinee_js.clone()),
-                                property: "value".to_string(),
-                            }),
+                            object: Box::new(scrutinee_js.clone()),
                             index: Box::new(JsExpr::String(i.to_string())),
                         };
                         bindings.push((ctx.resolve_name(&ident.name, &ident.span), accessor));

--- a/crates/husk-codegen-js/src/lib.rs
+++ b/crates/husk-codegen-js/src/lib.rs
@@ -3032,6 +3032,21 @@ fn count_newlines_in_stmt(stmt: &JsStmt) -> u32 {
             });
             1 + then_lines + else_lines
         }
+        JsStmt::Block(stmts) => {
+            // { + body lines + }
+            1 + stmts
+                .iter()
+                .map(|s| count_newlines_in_stmt(s) + 1)
+                .sum::<u32>()
+        }
+        JsStmt::Sequence(stmts) => {
+            // Statements at same level, each followed by newline except last
+            stmts
+                .iter()
+                .map(|s| count_newlines_in_stmt(s) + 1)
+                .sum::<u32>()
+                .saturating_sub(1)
+        }
         _ => 0, // single-line statements
     }
 }

--- a/crates/husk-fmt/src/visitor.rs
+++ b/crates/husk-fmt/src/visitor.rs
@@ -1125,7 +1125,9 @@ impl<'a> Formatter<'a> {
         }
     }
 
-    /// Format a statement inline (for else-if chains)
+    /// Format a statement inline (for else-if chains).
+    // TODO: Consider extracting shared If/IfLet formatting logic into a helper
+    // to reduce duplication with the corresponding branches in format_stmt.
     fn format_stmt_inline(&mut self, stmt: &Stmt) {
         match &stmt.kind {
             StmtKind::If {


### PR DESCRIPTION
## Summary

Implements Rust-style pattern matching sugar for conditional binding:

- `if let Pattern = expr { then } else { else }` - conditional pattern matching
- `let Pattern = expr else { diverge };` - extract or early return

## Changes

- **AST**: Add `else_block` to `StmtKind::Let`, add new `StmtKind::IfLet` variant
- **Parser**: Parse `if let` and `let ... else` syntax
- **Semantic**: Refutability checking for patterns, divergence analysis for else blocks
- **Formatter**: Format new syntax correctly
- **Codegen**: Generate correct JS with proper scoping using `JsStmt::Sequence` for let-else

## Examples

```rust
// if let - conditional pattern matching
if let Option::Some(x) = maybe_value {
    // x is bound here
} else {
    // fallback
}

// let ... else - extract or diverge
let Option::Some(value) = maybe else {
    return 0;  // must diverge (return, break, continue, panic)
};
// value is accessible here
```

## Test plan

- [x] All existing tests pass
- [x] Manual testing of if-let syntax
- [x] Manual testing of let-else syntax  
- [x] Verified generated JavaScript runs correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end support for let...else and if-let constructs across parsing, AST, formatting, semantic checks, and JS output.
  * JS emission adds stricter equality checks and explicit block/sequence constructs for lowered control flow.
* **Bug Fixes**
  * Parser and formatter correctly handle nested else-if and else-if-let chains.
* **Tests**
  * Expanded tests for let-else, if-let, pattern validation, and divergence scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->