### PR TITLE
feat(website): migrate code snippets to Shiki syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@
   <strong>A modern, Rust-inspired language that compiles to JavaScript with first-class developer experience</strong>
 </p>
 
-<!--
 <p align="center">
+  <!--
   <a href="https://github.com/fcoury/husk/actions">
     <img src="https://github.com/fcoury/husk/actions/workflows/rust.yml/badge.svg" alt="Build Status" />
   </a>
+  -->
   <a href="https://crates.io/crates/husk-lang">
     <img src="https://img.shields.io/crates/v/husk-lang.svg" alt="Crates.io" />
   </a>
@@ -21,19 +22,20 @@
     <img src="https://img.shields.io/badge/Website-husk--lang.org-orange.svg" alt="Website" />
   </a>
 </p>
--->
 
 Husk brings Rust's elegant syntax and safety to the JavaScript ecosystem. Write code with algebraic data types, pattern matching, and strong static typing, then seamlessly compile to clean, modern JavaScript that runs anywhere.
 
 ## Why Husk?
 
 **🎯 Rust-like Syntax, JavaScript Runtime**
+
 - Familiar syntax for Rust developers
 - Compiles to clean, readable ES modules or CommonJS
 - Interoperates seamlessly with npm packages
 - Zero-cost abstractions over JavaScript
 
 **⚡ Outstanding Developer Experience**
+
 - **Language Server (LSP)** with real-time diagnostics, hover info, and go-to-definition
 - **Code formatter** (`husk fmt`) for consistent style
 - **Editor support** for VS Code and Neovim with syntax highlighting and intelligent features
@@ -41,12 +43,14 @@ Husk brings Rust's elegant syntax and safety to the JavaScript ecosystem. Write 
 - **Watch mode** for instant feedback during development
 
 **🔒 Type Safety You Can Trust**
+
 - Strong static typing with inference
 - Exhaustive pattern matching on enums
 - Compile-time guarantees, runtime confidence
 - Result types (`Ok`/`Err`) for error handling
 
 **🚀 Built for Real-World Development**
+
 - Express.js integration examples
 - SQLite database support
 - npm package ecosystem access
@@ -136,9 +140,11 @@ husk fmt .
 ### Editor Support
 
 **VS Code**: Full LSP integration with syntax highlighting, diagnostics, hover, and go-to-definition
+
 - Install from `editors/vscode`
 
 **Neovim**: Syntax highlighting, indentation, and filetype detection
+
 - Install using your plugin manager: `'fcoury/husk.nvim'`
 
 ## Language Features
@@ -364,19 +370,19 @@ The compiler binary will be at `target/release/huskc`.
 
 Husk is implemented as a Rust workspace with specialized crates:
 
-| Crate | Purpose |
-|-------|---------|
-| `husk-ast` | Abstract syntax tree definitions |
-| `husk-lexer` | Tokenization and lexical analysis |
-| `husk-parser` | Recursive descent parser |
-| `husk-types` | Type system and inference |
-| `husk-semantic` | Semantic analysis and type checking |
-| `husk-codegen-js` | JavaScript code generation |
+| Crate             | Purpose                                          |
+| ----------------- | ------------------------------------------------ |
+| `husk-ast`        | Abstract syntax tree definitions                 |
+| `husk-lexer`      | Tokenization and lexical analysis                |
+| `husk-parser`     | Recursive descent parser                         |
+| `husk-types`      | Type system and inference                        |
+| `husk-semantic`   | Semantic analysis and type checking              |
+| `husk-codegen-js` | JavaScript code generation                       |
 | `husk-runtime-js` | JavaScript runtime helpers (Result, panic, etc.) |
-| `husk-lsp` | Language Server Protocol implementation |
-| `husk-fmt` | Code formatter |
-| `husk-dts-parser` | TypeScript definition parser |
-| `husk-cli` | Command-line interface |
+| `husk-lsp`        | Language Server Protocol implementation          |
+| `husk-fmt`        | Code formatter                                   |
+| `husk-dts-parser` | TypeScript definition parser                     |
+| `husk-cli`        | Command-line interface                           |
 
 ## JavaScript Runtime
 
@@ -401,6 +407,7 @@ MIT License - see [LICENSE](LICENSE) for details.
 ## Acknowledgments
 
 Husk draws inspiration from:
+
 - **Rust** - Syntax, type system, and pattern matching
 - **TypeScript** - JavaScript interop and tooling
 - **OCaml** - ML-family type inference

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -2,6 +2,8 @@
 import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
+import huskDark from './src/themes/husk-dark.json';
+import huskLight from './src/themes/husk-light.json';
 
 // https://astro.build/config
 export default defineConfig({
@@ -10,5 +12,17 @@ export default defineConfig({
   integrations: [sitemap()],
   vite: {
     plugins: [tailwindcss()]
-  }
+  },
+  markdown: {
+    shikiConfig: {
+      themes: {
+        light: huskLight,
+        dark: huskDark,
+      },
+      defaultColor: false,
+      langAlias: {
+        husk: 'rust',
+      },
+    },
+  },
 });

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -12,6 +12,9 @@
         "@tailwindcss/vite": "^4.1.17",
         "astro": "^5.16.4",
         "tailwindcss": "^4.1.17"
+      },
+      "devDependencies": {
+        "concurrently": "^9.2.1"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -2247,6 +2250,100 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -2264,6 +2361,26 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -2289,6 +2406,77 @@
       "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
       "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
       "license": "ISC"
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/cookie": {
       "version": "1.1.1",
@@ -2670,6 +2858,16 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -2776,6 +2974,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-east-asian-width": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
@@ -2815,6 +3023,16 @@
         "radix3": "^1.1.2",
         "ufo": "^1.6.1",
         "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/hast-util-from-html": {
@@ -4699,6 +4917,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/restructure": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
@@ -4771,7 +4999,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
       "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -4806,6 +5033,16 @@
         "@rollup/rollup-win32-x64-gnu": "4.53.3",
         "@rollup/rollup-win32-x64-msvc": "4.53.3",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/sax": {
@@ -4869,6 +5106,19 @@
         "@img/sharp-win32-arm64": "0.34.5",
         "@img/sharp-win32-ia32": "0.34.5",
         "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/shiki": {
@@ -5001,6 +5251,22 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/svgo": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.0.tgz",
@@ -5074,6 +5340,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/trim-lines": {
@@ -5488,7 +5764,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5634,6 +5909,35 @@
       "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
@@ -5641,6 +5945,51 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {
@@ -5687,7 +6036,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/website/package.json
+++ b/website/package.json
@@ -3,8 +3,9 @@
   "type": "module",
   "version": "0.0.1",
   "scripts": {
-    "dev": "astro dev",
-    "build": "astro build",
+    "dev": "concurrently \"cd ../docs && mdbook watch\" \"astro dev\"",
+    "dev:site": "astro dev",
+    "build": "cd ../docs && mdbook build && astro build",
     "preview": "astro preview",
     "astro": "astro"
   },
@@ -13,5 +14,8 @@
     "@tailwindcss/vite": "^4.1.17",
     "astro": "^5.16.4",
     "tailwindcss": "^4.1.17"
+  },
+  "devDependencies": {
+    "concurrently": "^9.2.1"
   }
 }

--- a/website/src/components/CodeBlock.astro
+++ b/website/src/components/CodeBlock.astro
@@ -1,0 +1,158 @@
+---
+import { Code } from 'astro:components';
+import huskLight from '../themes/husk-light.json';
+import huskDark from '../themes/husk-dark.json';
+
+interface Props {
+  code: string;
+  lang?: string;
+  filename?: string;
+  showCopy?: boolean;
+}
+
+// Use 'rust' for syntax highlighting since Husk is Rust-inspired
+const { code, lang = 'rust', filename, showCopy = false } = Astro.props;
+---
+
+<div class="code-block">
+  <div class="code-header">
+    <div class="code-dots">
+      <span></span>
+      <span></span>
+      <span></span>
+      {filename && <span class="filename">{filename}</span>}
+    </div>
+    {showCopy && (
+      <button class="copy-btn" data-code={code} aria-label="Copy to clipboard">
+        <svg class="copy-icon w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+        </svg>
+        <svg class="check-icon hidden w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path d="M20 6L9 17l-5-5" />
+        </svg>
+      </button>
+    )}
+  </div>
+  <div class="code-content">
+    <Code code={code} lang={lang} themes={{ light: huskLight, dark: huskDark }} defaultColor={false} />
+  </div>
+</div>
+
+<style>
+  .code-block {
+    position: relative;
+    background: linear-gradient(135deg, var(--color-surface-800) 0%, var(--color-surface-900) 100%);
+    border: 1px solid var(--color-surface-600);
+    border-radius: 12px;
+    overflow: hidden;
+  }
+
+  .code-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    background: var(--color-surface-700);
+    border-bottom: 1px solid var(--color-surface-600);
+  }
+
+  .code-dots {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .code-dots span:not(.filename) {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+  }
+
+  .code-dots span:nth-child(1) { background: #ff5f57; }
+  .code-dots span:nth-child(2) { background: #febc2e; }
+  .code-dots span:nth-child(3) { background: #28c840; }
+
+  .code-dots .filename {
+    margin-left: 12px;
+    font-size: 12px;
+    font-family: var(--font-mono, ui-monospace, monospace);
+    color: rgba(255, 255, 255, 0.6);
+  }
+
+  .copy-btn {
+    padding: 4px;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: var(--color-surface-400);
+    transition: color 0.2s;
+  }
+
+  .copy-btn:hover {
+    color: var(--color-cream-100);
+  }
+
+  .copy-btn .check-icon {
+    color: #28c840;
+  }
+
+  .copy-btn .hidden {
+    display: none;
+  }
+
+  .code-content {
+    padding: 16px 20px;
+    font-size: 14px;
+    line-height: 1.7;
+    overflow-x: auto;
+  }
+
+  .code-content :global(pre) {
+    margin: 0;
+    padding: 0;
+    background: transparent !important;
+  }
+
+  .code-content :global(code) {
+    font-family: var(--font-mono, ui-monospace, monospace);
+  }
+
+  /* Always use dark theme colors since code block has dark background */
+  .code-content :global(.astro-code),
+  .code-content :global(.astro-code span) {
+    color: var(--shiki-dark) !important;
+    background-color: transparent !important;
+  }
+</style>
+
+<script>
+  function setupCopyButtons() {
+    document.querySelectorAll('.copy-btn').forEach(btn => {
+      btn.addEventListener('click', async () => {
+        const code = btn.getAttribute('data-code');
+        if (!code) return;
+
+        try {
+          await navigator.clipboard.writeText(code);
+
+          const copyIcon = btn.querySelector('.copy-icon');
+          const checkIcon = btn.querySelector('.check-icon');
+
+          copyIcon?.classList.add('hidden');
+          checkIcon?.classList.remove('hidden');
+
+          setTimeout(() => {
+            copyIcon?.classList.remove('hidden');
+            checkIcon?.classList.add('hidden');
+          }, 2000);
+        } catch (err) {
+          console.error('Failed to copy:', err);
+        }
+      });
+    });
+  }
+
+  setupCopyButtons();
+  document.addEventListener('astro:after-swap', setupCopyButtons);
+</script>

--- a/website/src/components/CodeExamples.astro
+++ b/website/src/components/CodeExamples.astro
@@ -6,23 +6,18 @@ const examples = [
     id: 'pattern-matching',
     title: 'Pattern Matching',
     description: 'Exhaustive pattern matching with algebraic data types',
-    code: `enum Result<T, E> {
-    Ok(T),
-    Err(E),
-}
-
-fn divide(a: int, b: int) -> Result<int, string> {
+    code: `fn divide(a: i32, b: i32) -> Result<i32, String> {
     if b == 0 {
-        Result::Err("Division by zero")
+        Err("Division by zero")
     } else {
-        Result::Ok(a / b)
+        Ok(a / b)
     }
 }
 
 fn main() {
     match divide(10, 2) {
-        Result::Ok(value) => println!("Result: {}", value),
-        Result::Err(err) => println!("Error: {}", err),
+        Ok(value) => println("Result: {}", value),
+        Err(err) => println("Error: {}", err),
     }
     // Compiler ensures all cases are handled!
 }`,
@@ -32,24 +27,24 @@ fn main() {
     title: 'Structs & Methods',
     description: 'Define types with associated methods',
     code: `struct User {
-    name: string,
-    email: string,
-    age: int,
+    name: String,
+    email: String,
+    age: i32,
 }
 
 impl User {
-    fn new(name: string, email: string, age: int) -> User {
+    fn new(name: String, email: String, age: i32) -> User {
         User { name, email, age }
     }
 
-    fn greet(&self) -> string {
-        format!("Hi, I'm {} and I'm {} years old", self.name, self.age)
+    fn greet(&self) -> String {
+        format("Hi, I'm {} and I'm {} years old", self.name, self.age)
     }
 }
 
 fn main() {
     let user = User::new("Alice", "alice@example.com", 30);
-    println!("{}", user.greet());
+    println("{}", user.greet());
 }`,
   },
   {
@@ -60,8 +55,8 @@ fn main() {
 extern fn express() -> Express;
 
 struct Express {
-    extern fn get(&self, path: string, handler: fn(Request, Response) -> void) -> void;
-    extern fn listen(&self, port: int, callback: fn() -> void) -> void;
+    extern fn get(&self, path: String, handler: fn(Request, Response) -> void) -> void;
+    extern fn listen(&self, port: i32, callback: fn() -> void) -> void;
 }
 
 fn main() {
@@ -72,7 +67,7 @@ fn main() {
     });
 
     app.listen(3000, || {
-        println!("Server running on port 3000");
+        println("Server running on port 3000");
     });
 }`,
   },

--- a/website/src/components/CodeExamples.astro
+++ b/website/src/components/CodeExamples.astro
@@ -1,76 +1,78 @@
 ---
+import CodeBlock from './CodeBlock.astro';
+
 const examples = [
   {
     id: 'pattern-matching',
     title: 'Pattern Matching',
     description: 'Exhaustive pattern matching with algebraic data types',
-    code: `<span class="keyword">enum</span> <span class="type">Result</span>&lt;<span class="type">T</span>, <span class="type">E</span>&gt; {
-    <span class="function">Ok</span>(<span class="type">T</span>),
-    <span class="function">Err</span>(<span class="type">E</span>),
+    code: `enum Result<T, E> {
+    Ok(T),
+    Err(E),
 }
 
-<span class="keyword">fn</span> <span class="function">divide</span>(a: <span class="type">int</span>, b: <span class="type">int</span>) -> <span class="type">Result</span>&lt;<span class="type">int</span>, <span class="type">string</span>&gt; {
-    <span class="keyword">if</span> b == <span class="number">0</span> {
-        <span class="type">Result</span>::<span class="function">Err</span>(<span class="string">"Division by zero"</span>)
-    } <span class="keyword">else</span> {
-        <span class="type">Result</span>::<span class="function">Ok</span>(a / b)
+fn divide(a: int, b: int) -> Result<int, string> {
+    if b == 0 {
+        Result::Err("Division by zero")
+    } else {
+        Result::Ok(a / b)
     }
 }
 
-<span class="keyword">fn</span> <span class="function">main</span>() {
-    <span class="keyword">match</span> <span class="function">divide</span>(<span class="number">10</span>, <span class="number">2</span>) {
-        <span class="type">Result</span>::<span class="function">Ok</span>(value) => <span class="function">println!</span>(<span class="string">"Result: {}"</span>, value),
-        <span class="type">Result</span>::<span class="function">Err</span>(err) => <span class="function">println!</span>(<span class="string">"Error: {}"</span>, err),
+fn main() {
+    match divide(10, 2) {
+        Result::Ok(value) => println!("Result: {}", value),
+        Result::Err(err) => println!("Error: {}", err),
     }
-    <span class="comment">// Compiler ensures all cases are handled!</span>
+    // Compiler ensures all cases are handled!
 }`,
   },
   {
     id: 'structs-methods',
     title: 'Structs & Methods',
     description: 'Define types with associated methods',
-    code: `<span class="keyword">struct</span> <span class="type">User</span> {
-    name: <span class="type">string</span>,
-    email: <span class="type">string</span>,
-    age: <span class="type">int</span>,
+    code: `struct User {
+    name: string,
+    email: string,
+    age: int,
 }
 
-<span class="keyword">impl</span> <span class="type">User</span> {
-    <span class="keyword">fn</span> <span class="function">new</span>(name: <span class="type">string</span>, email: <span class="type">string</span>, age: <span class="type">int</span>) -> <span class="type">User</span> {
-        <span class="type">User</span> { name, email, age }
+impl User {
+    fn new(name: string, email: string, age: int) -> User {
+        User { name, email, age }
     }
 
-    <span class="keyword">fn</span> <span class="function">greet</span>(&<span class="keyword">self</span>) -> <span class="type">string</span> {
-        <span class="function">format!</span>(<span class="string">"Hi, I'm {} and I'm {} years old"</span>, <span class="keyword">self</span>.name, <span class="keyword">self</span>.age)
+    fn greet(&self) -> string {
+        format!("Hi, I'm {} and I'm {} years old", self.name, self.age)
     }
 }
 
-<span class="keyword">fn</span> <span class="function">main</span>() {
-    <span class="keyword">let</span> user = <span class="type">User</span>::<span class="function">new</span>(<span class="string">"Alice"</span>, <span class="string">"alice@example.com"</span>, <span class="number">30</span>);
-    <span class="function">println!</span>(<span class="string">"{}"</span>, user.<span class="function">greet</span>());
+fn main() {
+    let user = User::new("Alice", "alice@example.com", 30);
+    println!("{}", user.greet());
 }`,
   },
   {
     id: 'js-interop',
     title: 'JavaScript Interop',
     description: 'Seamlessly use npm packages',
-    code: `<span class="comment">// Use Express.js directly from Husk</span>
-<span class="keyword">extern</span> <span class="keyword">fn</span> <span class="function">express</span>() -> <span class="type">Express</span>;
+    code: `// Use Express.js directly from Husk
+extern fn express() -> Express;
 
-<span class="keyword">struct</span> <span class="type">Express</span> {
-    <span class="keyword">extern</span> <span class="keyword">fn</span> <span class="function">get</span>(&<span class="keyword">self</span>, path: <span class="type">string</span>, handler: <span class="keyword">fn</span>(<span class="type">Request</span>, <span class="type">Response</span>) -> <span class="type">void</span>) -> <span class="type">void</span>;
-    <span class="keyword">extern</span> <span class="keyword">fn</span> <span class="function">listen</span>(&<span class="keyword">self</span>, port: <span class="type">int</span>, callback: <span class="keyword">fn</span>() -> <span class="type">void</span>) -> <span class="type">void</span>;
+struct Express {
+    extern fn get(&self, path: string, handler: fn(Request, Response) -> void) -> void;
+    extern fn listen(&self, port: int, callback: fn() -> void) -> void;
 }
 
-<span class="keyword">fn</span> <span class="function">main</span>() {
-    <span class="keyword">let</span> app = <span class="function">express</span>();
+fn main() {
+    let app = express();
 
-    app.<span class="function">get</span>(<span class="string">"/"</span>, |req, res| {
-        res.<span class="function">send</span>(<span class="string">"Hello from Husk!"</span>);
+    app.get("/", |req, res| {
+        res.send("Hello from Husk!");
     });
 
-    app.<span class="function">listen</span>(<span class="number">3000</span>, || {
-        <span class="function">println!</span>(<span class="string">"Server running on port 3000"</span>);
+    app.listen(3000, || {
+        println!("Server running on port 3000");
     });
 }`,
   },
@@ -129,17 +131,8 @@ const examples = [
           </p>
 
           <!-- Code block -->
-          <div class="code-block max-w-4xl mx-auto shadow-2xl shadow-surface-900/10 dark:shadow-black/30">
-            <!-- Window chrome -->
-            <div class="code-dots">
-              <span></span>
-              <span></span>
-              <span></span>
-              <span class="ml-4 text-xs text-cream-100/60 font-mono whitespace-nowrap">{example.id}.hk</span>
-            </div>
-
-            <!-- Code content -->
-            <pre class="code-content text-cream-100"><code set:html={example.code} /></pre>
+          <div class="max-w-4xl mx-auto shadow-2xl shadow-surface-900/10 dark:shadow-black/30">
+            <CodeBlock code={example.code} filename={`${example.id}.hk`} />
           </div>
         </div>
       ))}

--- a/website/src/components/Community.astro
+++ b/website/src/components/Community.astro
@@ -20,7 +20,7 @@ const resources = [
   {
     title: 'Discord',
     description: 'Join the community, ask questions, and connect with other Husk developers.',
-    href: 'https://discord.gg/husk-lang',
+    href: 'https://discord.gg/xCFQg7UN9s',
     icon: 'discord',
     cta: 'Join Discord',
     available: true,

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -1,17 +1,18 @@
 ---
 import { Image } from 'astro:assets';
 import logo from '../assets/logo.png';
+import CodeBlock from './CodeBlock.astro';
 
-const codeExample = `<span class="keyword">enum</span> <span class="type">Result</span>&lt;<span class="type">T</span>, <span class="type">E</span>&gt; {
-    <span class="function">Ok</span>(<span class="type">T</span>),
-    <span class="function">Err</span>(<span class="type">E</span>),
+const codeExample = `enum Result<T, E> {
+    Ok(T),
+    Err(E),
 }
 
-<span class="keyword">fn</span> <span class="function">main</span>() {
-    <span class="keyword">let</span> result = <span class="type">Result</span>::<span class="function">Ok</span>(<span class="number">42</span>);
-    <span class="keyword">match</span> result {
-        <span class="type">Result</span>::<span class="function">Ok</span>(n) => <span class="function">println!</span>(<span class="string">"Got: {}"</span>, n),
-        <span class="type">Result</span>::<span class="function">Err</span>(e) => <span class="function">println!</span>(<span class="string">"Error: {}"</span>, e),
+fn main() {
+    let result = Result::Ok(42);
+    match result {
+        Result::Ok(n) => println!("Got: {}", n),
+        Result::Err(e) => println!("Error: {}", e),
     }
 }`;
 ---
@@ -116,15 +117,7 @@ const codeExample = `<span class="keyword">enum</span> <span class="type">Result
 
       <!-- Right column - Code example (hidden on mobile) -->
       <div class="hidden lg:block opacity-0 animate-fade-in-up delay-200">
-        <div class="code-block">
-          <div class="code-dots">
-            <span></span>
-            <span></span>
-            <span></span>
-            <span class="ml-4 text-xs text-cream-100/60 font-mono">main.hk</span>
-          </div>
-          <pre class="code-content text-cream-100 text-sm leading-relaxed"><code set:html={codeExample} /></pre>
-        </div>
+        <CodeBlock code={codeExample} filename="main.hk" />
       </div>
     </div>
   </div>

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -3,16 +3,19 @@ import { Image } from 'astro:assets';
 import logo from '../assets/logo.png';
 import CodeBlock from './CodeBlock.astro';
 
-const codeExample = `enum Result<T, E> {
-    Ok(T),
-    Err(E),
+const codeExample = `fn divide(a: i32, b: i32) -> Result<i32, String> {
+    if b == 0 {
+        Err("Division by zero")
+    } else {
+        Ok(a / b)
+    }
 }
 
 fn main() {
-    let result = Result::Ok(42);
-    match result {
-        Result::Ok(n) => println!("Got: {}", n),
-        Result::Err(e) => println!("Error: {}", e),
+    // Compiler ensures all cases are handled!
+    match divide(10, 2) {
+        Ok(value) => println("Result: {}", value),
+        Err(err) => println("Error: {}", err),
     }
 }`;
 ---

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -253,62 +253,6 @@ code, pre {
 .delay-700 { animation-delay: 700ms; }
 .delay-800 { animation-delay: 800ms; }
 
-/* Code Block Styling */
-.code-block {
-  position: relative;
-  background: linear-gradient(135deg, var(--color-surface-800) 0%, var(--color-surface-900) 100%);
-  border: 1px solid var(--color-surface-600);
-  border-radius: 12px;
-  overflow: hidden;
-}
-
-.code-block::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 40px;
-  background: var(--color-surface-700);
-  border-bottom: 1px solid var(--color-surface-600);
-}
-
-/* Code Window Dots */
-.code-dots {
-  display: flex;
-  gap: 6px;
-  padding: 12px 16px;
-  position: relative;
-  z-index: 1;
-}
-
-.code-dots span {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-}
-
-.code-dots span:nth-child(1) { background: #ff5f57; }
-.code-dots span:nth-child(2) { background: #febc2e; }
-.code-dots span:nth-child(3) { background: #28c840; }
-
-/* Syntax Highlighting (Rust-like for Husk) */
-.code-content {
-  padding: 16px 20px;
-  font-size: 14px;
-  line-height: 1.7;
-  overflow-x: auto;
-}
-
-.code-content .keyword { color: #ff7b72; }
-.code-content .function { color: #d2a8ff; }
-.code-content .string { color: #a5d6ff; }
-.code-content .type { color: #79c0ff; }
-.code-content .number { color: #ffa657; }
-.code-content .comment { color: #8b949e; font-style: italic; }
-.code-content .operator { color: #ff7b72; }
-.code-content .punctuation { color: #c9d1d9; }
-
 /* Button Styles */
 .btn-primary {
   background: linear-gradient(135deg, var(--color-husk-500) 0%, var(--color-husk-600) 100%);

--- a/website/src/themes/husk-dark.json
+++ b/website/src/themes/husk-dark.json
@@ -1,0 +1,111 @@
+{
+  "name": "husk-dark",
+  "type": "dark",
+  "colors": {
+    "editor.background": "#1a1a2e",
+    "editor.foreground": "#c9d1d9"
+  },
+  "tokenColors": [
+    {
+      "scope": ["comment", "punctuation.definition.comment"],
+      "settings": {
+        "foreground": "#8b949e",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": [
+        "keyword",
+        "keyword.control",
+        "keyword.operator",
+        "storage.type",
+        "storage.modifier"
+      ],
+      "settings": {
+        "foreground": "#ff7b72"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.function",
+        "meta.function-call",
+        "support.function",
+        "entity.name.function.macro"
+      ],
+      "settings": {
+        "foreground": "#d2a8ff"
+      }
+    },
+    {
+      "scope": [
+        "string",
+        "string.quoted",
+        "punctuation.definition.string"
+      ],
+      "settings": {
+        "foreground": "#a5d6ff"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.type",
+        "entity.name.class",
+        "support.type",
+        "support.class",
+        "entity.name.type.class",
+        "storage.type.primitive"
+      ],
+      "settings": {
+        "foreground": "#79c0ff"
+      }
+    },
+    {
+      "scope": [
+        "constant.numeric",
+        "constant.language",
+        "constant.character"
+      ],
+      "settings": {
+        "foreground": "#ffa657"
+      }
+    },
+    {
+      "scope": [
+        "punctuation",
+        "punctuation.separator",
+        "punctuation.terminator"
+      ],
+      "settings": {
+        "foreground": "#c9d1d9"
+      }
+    },
+    {
+      "scope": [
+        "variable",
+        "variable.parameter",
+        "variable.other"
+      ],
+      "settings": {
+        "foreground": "#c9d1d9"
+      }
+    },
+    {
+      "scope": [
+        "variable.language.self",
+        "variable.language.this"
+      ],
+      "settings": {
+        "foreground": "#ff7b72"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.tag",
+        "entity.name.namespace"
+      ],
+      "settings": {
+        "foreground": "#7ee787"
+      }
+    }
+  ]
+}

--- a/website/src/themes/husk-light.json
+++ b/website/src/themes/husk-light.json
@@ -1,0 +1,111 @@
+{
+  "name": "husk-light",
+  "type": "light",
+  "colors": {
+    "editor.background": "#faf8f5",
+    "editor.foreground": "#24292f"
+  },
+  "tokenColors": [
+    {
+      "scope": ["comment", "punctuation.definition.comment"],
+      "settings": {
+        "foreground": "#6e7781",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": [
+        "keyword",
+        "keyword.control",
+        "keyword.operator",
+        "storage.type",
+        "storage.modifier"
+      ],
+      "settings": {
+        "foreground": "#cf222e"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.function",
+        "meta.function-call",
+        "support.function",
+        "entity.name.function.macro"
+      ],
+      "settings": {
+        "foreground": "#8250df"
+      }
+    },
+    {
+      "scope": [
+        "string",
+        "string.quoted",
+        "punctuation.definition.string"
+      ],
+      "settings": {
+        "foreground": "#0a3069"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.type",
+        "entity.name.class",
+        "support.type",
+        "support.class",
+        "entity.name.type.class",
+        "storage.type.primitive"
+      ],
+      "settings": {
+        "foreground": "#0550ae"
+      }
+    },
+    {
+      "scope": [
+        "constant.numeric",
+        "constant.language",
+        "constant.character"
+      ],
+      "settings": {
+        "foreground": "#953800"
+      }
+    },
+    {
+      "scope": [
+        "punctuation",
+        "punctuation.separator",
+        "punctuation.terminator"
+      ],
+      "settings": {
+        "foreground": "#24292f"
+      }
+    },
+    {
+      "scope": [
+        "variable",
+        "variable.parameter",
+        "variable.other"
+      ],
+      "settings": {
+        "foreground": "#24292f"
+      }
+    },
+    {
+      "scope": [
+        "variable.language.self",
+        "variable.language.this"
+      ],
+      "settings": {
+        "foreground": "#cf222e"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.tag",
+        "entity.name.namespace"
+      ],
+      "settings": {
+        "foreground": "#116329"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Replace manual HTML span-based syntax highlighting with Astro's built-in Shiki highlighter
- Create custom `husk-dark` and `husk-light` themes matching existing color scheme
- Add reusable `CodeBlock` component wrapping Shiki's `<Code />` with window chrome (dots, filename header)
- Migrate Hero.astro (1 example) and CodeExamples.astro (3 tabbed examples) to use CodeBlock
- Configure Rust grammar alias for Husk language in astro.config.mjs
- Remove unused manual syntax highlighting CSS classes from global.css

## Benefits

- **Maintainability**: Adding new code examples takes <5 minutes without manual HTML annotation
- **Correctness**: No error-prone manual token coloring required
- **Scalability**: Proper syntax highlighting for all Rust/Husk constructs
- **Performance**: Shiki is built into Astro, no additional dependencies

## Test plan

- [ ] Build completes without errors (`npm run build`)
- [ ] All 4 code examples render with proper syntax highlighting
- [ ] Dark mode toggle works correctly
- [ ] Tab switching in CodeExamples works
- [ ] Visual appearance matches original design

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable code block component with copy-to-clipboard and filename display.
  * Introduced matching light and dark syntax themes and enabled theming for code rendering.

* **Refactor**
  * Replaced inline code HTML with the new unified code block across examples and hero.

* **Style**
  * Consolidated legacy code-block CSS into component-specific styling.

* **Chores**
  * Updated local dev/build scripts.

* **Documentation**
  * Minor README formatting and a community link update.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->